### PR TITLE
Removes stray closing erb tag

### DIFF
--- a/app/views/person_mailer/new_member_email.html.erb
+++ b/app/views/person_mailer/new_member_email.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= @person.first_name %> has joined your group! </p>
 
-<p> That means it's cake time! %>
+<p> That means it's cake time!
 
 <% if @person.twitter? %>
   They are on twitter: @<%= @person.twitter %>


### PR DESCRIPTION
I received this email:

> Dear Rails Girls Atlanta
> 
> Pamela has joined your group!
> 
> That means it's cake time! %> They are on twitter: @pwnela
> 
> You can find out more about your latest member by heading over to your project group page.
> 
> Best wishes from the RailsGirlsApp

So I did a quick delete of that pesky `%>`!
