### PR TITLE
remove is_ prefix for boolean methods

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,7 @@ class GroupsController < ApplicationController
 
   def edit
     @group = Group.find(params[:id])
-    if !@group.is_editable_by?(current_person)
+    if !@group.editable_by?(current_person)
       redirect_to root_path, notice: 'You don\'t have permission to view this page.'
     end
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -64,7 +64,7 @@ class TopicsController < ApplicationController
 
   def validate_user_group_member
     group = Group.find params[:group_id]
-    unless group.is_editable_by? current_person
+    unless group.editable_by? current_person
       redirect_to group_path(params[:group_id]),
                   notice: 'You are not allowed to do that'
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -37,11 +37,11 @@ class Group < ActiveRecord::Base
   geocoded_by :address
   after_validation :geocode
 
-  def is_editable_by?(person)
+  def editable_by?(person)
     people.include?(person)
   end
 
-  def is_deletable_by?(person)
+  def deletable_by?(person)
     person && person.has_role?(:admin)
   end
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -22,10 +22,10 @@
               <td><%= group.time %></td>
               <td><%= group.address %></td>
               <td>
-                <%= if group.is_editable_by?(current_person)
+                <%= if group.editable_by?(current_person)
                     link_to("edit", edit_group_path(group))
                   end %>
-                <%= if group.is_deletable_by?(current_person)
+                <%= if group.deletable_by?(current_person)
                     link_to("delete", group_path(group), :method => :delete, :confirm => 'Are you sure you want to delete this group?')
                   end %>
               </td>

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -51,13 +51,13 @@ describe GroupsController do
     end
 
     it 'restricts access if editable is false' do
-      group.stub(:is_editable_by?).with(person).and_return(false)
+      group.stub(:editable_by?).with(person).and_return(false)
       get :edit, id: 1
       expect(response).to be_redirect
     end
 
     it 'allows access if editable is true' do
-      group.stub(:is_editable_by?).with(person).and_return(true)
+      group.stub(:editable_by?).with(person).and_return(true)
       get :edit, id: 1
       expect { get :edit }.to render_template(:edit)
     end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -34,11 +34,11 @@ describe Group do
 
     it 'is editable by people in the group' do
       person.join!(group)
-      expect(group.is_editable_by?(person)).to be_true
+      expect(group.editable_by?(person)).to be_true
     end
 
     it 'is not editable by people not in the group' do
-      expect(group.is_editable_by?(person)).to be_false
+      expect(group.editable_by?(person)).to be_false
     end
   end
 
@@ -46,16 +46,16 @@ describe Group do
 
     it 'is not deletable by a person that just joined' do
       person.join!(group)
-      expect(group).not_to be_is_deletable_by person
+      expect(group).not_to be_deletable_by person
     end
 
     it 'is deletable by an admin' do
       person.add_role :admin
-      expect(group).to be_is_deletable_by person
+      expect(group).to be_deletable_by person
     end
 
     it 'handles nil values for not logged in users gracefully' do
-      expect(group).not_to be_is_deletable_by nil
+      expect(group).not_to be_deletable_by nil
     end
 
   end


### PR DESCRIPTION
The is_ prefix to me is more Java-ish. In Ruby boolean methods
are commonly denoted by just appending the ? so it feels kind
of un ruby-ish to me. Let me know what you think though ;)
