### PR TITLE
add forgotten spring file

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast
+# It gets overwritten when you run the `spring binstub` command
+
+unless defined?(Spring)
+  require "rubygems"
+  require "bundler"
+
+  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    spring \((.*?)\)$.*?^$/m)
+    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
+    ENV["GEM_HOME"] = ""
+    Gem.paths = ENV
+
+    gem "spring", match[1]
+    require "spring/binstub"
+  end
+end


### PR DESCRIPTION
This file somehow showed up among my local changes, while I was working on something completely unrelated. Tam and I were guessing it's a remnant from the Rails 4.0 to 4.1. update, which Tam did on my machine. Any opinions on that, @til ?
