### PR TITLE
Restrict topics routes to those that are needed

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,10 +3,6 @@ class TopicsController < ApplicationController
   before_action :validate_user_group_member
   before_action :authenticate_person!
 
-  def new
-    @topic = Topic.new
-  end
-
   def edit
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ RailsGirlsApp::Application.routes.draw do
   get 'about' => 'pages#about', as: :about
   #resources routing declare all of the common routes for the certain controller (index, new, edit etc...)
   resources :groups do
-    resources :topics
+    resources :topics, only: [:create, :edit, :update, :destroy]
   end
   resources :people
   resources :memberships, only: [:create, :destroy]

--- a/spec/routing/topics_spec.rb
+++ b/spec/routing/topics_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'routing to topics' do
+  it 'routes create' do
+    expect(post: '/groups/:id/topics').to be_routable
+  end
+
+  it 'routes edit' do
+    expect(get: '/groups/:id/topics/:topic_id/edit').to be_routable
+  end
+
+  it 'routes update' do
+    expect(put: '/groups/:id/topics/:topic_id').to be_routable
+  end
+
+  it 'routes destroy' do
+    expect(delete: '/groups/:id/topics/:topic_id').to be_routable
+  end
+
+  it 'does not route show' do
+    expect(get: '/groups/:id/topics/:topic_id').to_not be_routable
+  end
+
+  it 'does not route index' do
+    expect(get: '/groups/:id/topics').to_not be_routable
+  end
+end


### PR DESCRIPTION
This makes the output of rake routes more concise, and produces better
error messages when someone accidentially visits one of those URLs.

It might make sense to go over the other resources in the routes file as
well and check what can be further restricted.

Also remove the new action from TopicsController which is not used.

Refs #295 by @acrogenesis which accidentially fell victim to a
misinterpretation on my part. Mea culpa.
