### PR TITLE
Makes contact info and email required for groups.

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
 	function removeAlert() {
 		$('.alert').addClass('fade-out');
 	}
-	window.setTimeout(removeAlert, 3000);
+	window.setTimeout(removeAlert, 5000);
 
 	makeGif();
 

--- a/app/assets/stylesheets/custom/custom.css.scss
+++ b/app/assets/stylesheets/custom/custom.css.scss
@@ -52,12 +52,14 @@
 // flash messages
 .alert {
   position: fixed;
-  left: 0;
-  right: 0;
+  left: 10%;
+  right: 10%;
+  border: 2px solid black;
   top: 4em;
   width: 80%;
   z-index: 1031; // bootstrap sets the navbar to 1030
-  opacity: 0.9;
+  background-color: pink;
+  opacity: 1;
   transform: translate(0);
   padding: 4px 30px;
   &.fade-out {

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -33,7 +33,8 @@ class Group < ActiveRecord::Base
   has_many :coach_memberships
 
   validates :name, presence: true
-  validates :email, format: { with: FORMAT }, allow_blank: true
+  validates :email, format: { with: FORMAT }, presence: true
+  validates :contact, presence: true
 
   mount_uploader :picture, PictureUploader
   geocoded_by :location

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,20 +15,20 @@
       = f.label(:address, "Meeting place")
       = f.text_field :address, placeholder: 'Where you meet', class: 'form-control'
     .form-group
-      = f.label(:city, "City")
+      = f.label(:city, "City *")
       = f.text_field :city, placeholder: 'In what city', class: 'form-control'
     .form-group
-      = f.label(:country, "Country")
+      = f.label(:country, "Country *")
       = f.country_select(:country, {priority_countries: ["DE", "PL", "IN", "US"], include_blank: true}, {class: 'form-control'})
   .col-md-4
     .form-group
       = f.label(:twitter, "Twitter handle")
       = f.text_field :twitter, placeholder: '@twitterhandle', class: 'form-control'
     .form-group
-      = f.label(:email, "Where we'll send official emails")
+      = f.label(:email, "Where we'll send official emails *")
       = f.text_field :email, placeholder: "email@address.com", class: 'form-control'
     .form-group
-      = f.label(:contact, "Contact info")
+      = f.label(:contact, "Contact info *")
       = f.text_area :contact, placeholder: 'How to contact your group', class: 'form-control'
     .form-group
       = label_tag(:activities, "Description (you can use markdown!)")

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -2,6 +2,7 @@
   .row
     .col-md-12.page-header
       %h2 Register a new group
+      %h5 Fields with * are required
   .row
     = render 'form'
     .col-md-4

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -5,4 +5,4 @@
       %ul
         - object.errors.full_messages.each do |msg|
           %li
-            * #{msg}
+            #{msg}

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -6,7 +6,7 @@ describe GroupsController do
     let(:person) { create(:person) }
 
     context 'with correct params' do
-      let(:params) {{ group: { name: 'rubycorns' } }}
+      let(:params) {{ group: { name: 'rubycorns', email: 'test@tehest.com', contact: 'fruitcakes' } }}
 
       before do
         allow(controller).to receive :authenticate_person!

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -23,10 +23,12 @@ FactoryGirl.define do
   factory :group do
     name 'Test Group'
     email 'testgroup@email.com'
+    contact 'some googlegroup'
   end
 
   factory :second_group, class: Group do
     name 'Second Group'
     email 'secondgroup@email.com'
+    contact 'some other googlegroup'
   end
 end

--- a/spec/features/group_create_spec.rb
+++ b/spec/features/group_create_spec.rb
@@ -12,6 +12,8 @@ feature 'create a group' do
     click_link 'Groups'
     click_link 'register new group'
     fill_in 'Project group name', with: 'Testgroup'
+    fill_in 'Where we\'ll send official emails', with: 'test@email.com'
+    fill_in 'Contact info', with: 'this googlegroup'
     expect(page).to have_content('Join group as coach')
     check 'Join group as coach'
     expect(page).to_not have_content('Is your group full?')
@@ -35,6 +37,8 @@ feature 'create a group' do
     click_link 'Groups'
     click_link 'register new group'
     fill_in 'Project group name', with: 'Testgroup'
+    fill_in 'Where we\'ll send official emails', with: 'test@email.com'
+    fill_in 'Contact info', with: 'this googlegroup'
     expect(page).to have_content('Join group as coach')
     click_button 'Create Group'
 


### PR DESCRIPTION
+ Group email = required
+ Contact info = required
+ Styles for flash messages updated to pink background and centered
+ All tests pass

We both fields necessary because email is for us (the app maintainers) whereas contact info is for people interested in the group.
Because most groups use googlegroups we didn't change contact info to email field.
