### PR TITLE
Add publication date to posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :development, :test do
   gem 'launchy'
   gem 'minitest'
   gem 'rspec-its', '~> 1.0.1'
+  gem 'timecop'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    timecop (0.7.3)
     timers (1.1.0)
     treetop (1.4.15)
       polyglot
@@ -334,6 +335,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sqlite3
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   will_paginate

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,6 +27,8 @@ class PostsController < ApplicationController
     @post.draft = post_params_draft
     @post.person = current_person
 
+    @post.set_published_on! if !@post.draft
+
     if @post.save
       redirect_to @post, notice: post_created_notice
     else
@@ -35,9 +37,12 @@ class PostsController < ApplicationController
   end
 
   def update
-
     @post.draft = post_params_draft
 
+    if !@post.draft && @post.draft_changed?
+      @post.set_published_on!
+    end
+      
     if @post.update(post_params)
       redirect_to @post, notice: 'Post was successfully updated.
       All efforts, nomatter how small, deserve cake.'

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,3 +1,10 @@
 module PostsHelper
 
+  def show_date(post)
+    if post.published_on.present?
+      post.published_on.strftime("%d %b %Y")
+    else
+      "draft created on #{post.created_at.strftime("%d %b %Y")}"
+    end
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,4 +21,7 @@ class Post < ActiveRecord::Base
 
   mount_uploader :picture, PictureUploader
 
+  def set_published_on!
+    update_attribute(:published_on, Date.today)
+  end
 end

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -6,7 +6,7 @@
     %p.post-meta
       = post.person.first_name if post.person
       |
-      \#{post.created_at.strftime("%d %b %Y")}
+      \#{show_date(post)}
   %main
     .post-body
       = markdown(post.description)

--- a/db/migrate/20150514115024_add_publication_date_to_post.rb
+++ b/db/migrate/20150514115024_add_publication_date_to_post.rb
@@ -1,0 +1,5 @@
+class AddPublicationDateToPost < ActiveRecord::Migration
+  def change
+    add_column :posts, :published_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150317183935) do
+ActiveRecord::Schema.define(version: 20150514115024) do
 
   create_table "groups", force: true do |t|
     t.string   "name"
@@ -86,7 +86,8 @@ ActiveRecord::Schema.define(version: 20150317183935) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "person_id"
-    t.boolean  "draft",       default: false, null: false
+    t.boolean  "draft",        default: false, null: false
+    t.date     "published_on"
   end
 
   create_table "roles", force: true do |t|

--- a/lib/tasks/blogpost_publish_dates.rake
+++ b/lib/tasks/blogpost_publish_dates.rake
@@ -1,0 +1,16 @@
+task set_blogpost_published_ons: :environment do
+  puts "Finding blogposts with empty publish dates"
+  posts = Post.where(published_on: nil)
+
+  if posts.count > 0
+    puts "There are #{posts.count} blogposts with empty publication dates. I'll change them!"
+    
+    posts.map do |post|
+      post.update_attribute(:published_on, post.created_at)
+    end
+    
+    puts "Done! have some cake!"
+  else
+    puts "Nothing to do here! Go have some cake."
+  end
+end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe PostsController do
   describe 'index' do
-
     context 'no posts whatsoever' do
 
       before :each do
@@ -29,6 +28,169 @@ describe PostsController do
         expect(assigns(:posts).to_a.size).to eq 5
       end
 
+    end
+  end
+
+  describe 'create' do
+    test_date = Date.new(2015, 05, 12)
+
+    before do 
+      Timecop.freeze(test_date)
+      allow(controller).to receive :authenticate_person!
+      allow(controller).to receive(:current_person).and_return(person)
+    end
+
+    after { Timecop.return }
+
+    let(:person) { create :person }
+    let(:params) {{ post: {title: 'something', description: 'stuff'}, commit: 'Publish'} }
+
+    context 'creating a post' do
+      context 'as a non-admin' do
+
+        it 'does not create a post' do
+          expect do
+            post :create, params
+          end.to_not change{ Post.count}
+        end
+      end
+
+      context 'as an admin' do
+
+        before do
+          person.add_role :admin
+          person.save
+        end
+
+        context 'publishing the post' do
+          it 'is successful' do
+            expect do
+              post :create, params
+            end.to change{ Post.count}.by(1)
+          end
+
+          it 'does not mark the post as a draft' do
+            post :create, params
+            expect(Post.last.draft).to be false
+          end
+
+          it 'sets the correct published_on date' do
+            post :create, params
+            expect(Post.last.published_on).to eql test_date
+          end
+
+          it 'redirects to the post' do
+            post :create, params
+            expect(response).to redirect_to post_path(Post.last)
+          end
+        end
+
+        context 'saving the post as draft' do
+          let(:params)  {
+                          { post: 
+                            { title: 'something', 
+                              description: 'stuff'
+                            }, 
+                          commit: 'Save as draft'
+                          } 
+                        }
+
+          it 'is successful' do
+            expect do
+              post :create, params
+            end.to change{ Post.count}.by(1)
+          end
+
+          it 'marks the post as a draft' do
+            post :create, params
+            expect(Post.last.draft).to be true
+          end 
+
+          it 'sets the correct published_on date' do
+            post :create, params
+            expect(Post.last.published_on).to be_nil
+          end
+
+          it 'redirects to the post' do
+            post :create, params
+            expect(response).to redirect_to post_path(Post.last)
+          end 
+        end
+      end
+    end
+  end
+
+  describe 'update' do
+    before do 
+      allow(controller).to receive :authenticate_person!
+      allow(controller).to receive(:current_person).and_return(person)
+    end
+
+    let(:person) { create :person }
+    let(:post)   { create :post, published_on: Date.new(2015, 01, 01) }
+    let(:params)  {
+                    { post: 
+                      { title: 'blargh!', 
+                        description: 'things are happening!'
+                      }, 
+                      id: post.id, 
+                      commit: 'Publish'
+                    } 
+                  }
+
+    context 'as an admin' do
+
+      before do
+        person.add_role :admin
+        person.save
+        allow(Post).to receive(:find).and_return(post)
+      end
+
+      context 'updating the post' do
+        it 'is successful' do
+          expect do
+            put :update, params
+          end.to_not change{ Post.count }
+        end
+
+        it 'does not mark the post as a draft' do
+          put :update, params
+          expect(post.draft).to be false
+        end
+
+        it 'keeps the old published_on date' do
+          put :update, params
+          expect(post.published_on).to eq Date.new(2015, 01, 01)
+        end
+
+        it 'redirects to the post' do
+          put :update, params
+          expect(response).to redirect_to post_path(post)
+        end
+      end
+
+      context 'publishing a draft' do
+        test_date = Date.new(2015, 05, 12)
+        before { Timecop.freeze(test_date) }
+        after { Timecop.return }
+
+        let(:post) { create :post, draft: true, published_on: nil }
+
+        it 'does not mark the post as draft' do
+          put :update, params
+          expect(post.draft).to be false
+        end 
+
+        it 'sets the correct published_on date' do
+          put :update, params
+          expect(post.published_on).to eql test_date
+        end
+
+        it 'redirects to the post' do
+          put :update, params
+          expect(response).to redirect_to post_path(post)
+        end 
+      end
     end
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :post do
+    title 'A blogpost'
+    description 'about stuff'
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Post do
+
+  it { is_expected.to belong_to(:person) }
+
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:description) }
+
+  describe '#set_published_on!' do
+    let(:post) { create :post, published_on: nil }
+    test_date = Date.new(2015, 05, 12)
+
+    before do
+      Timecop.freeze(test_date)
+      post.set_published_on!
+    end
+
+    after { Timecop.return }
+    
+    it 'sets the correct date' do
+      expect(post.published_on).to eql test_date
+    end
+  end
+end


### PR DESCRIPTION
I'm so lost at the moment. This is so solve the bug https://github.com/rubycorns/rorganize.it/issues/327. I decided not to use the `updated_at` column as the publication date, because what if someone updates an old post!? It's publication date would change! That would just be madness. So I created a new `publication_date` column for posts and am trying to use that.

In post#update, I'm trying to set a post's publication date if it was previously a draft, and is no longer. That's the `!@post.draft && @post.draft_changed?` part. 

Then the `@post.set_publication_date!` method is called, which should set the post's publication date. 
IT DOES. I can see it happening with all of my crazy ramblings in the code there where I look to see if it's been set. 

However, once the post is reloaded, it loses its publication date! why?! For some reason it's not being saved.... and I can't figure it out, help please!

ps - in my opinion, and in the internet'z opionion, `update_attribute(:publication_date, Date.today)` should save the object... which only furthers my confusion. My guess is it's being overwritten somewhere. But I don't know where. 