### PR TITLE
Learning resources

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -66,7 +66,8 @@ class GroupsController < ApplicationController
   def group_params
     params.require(:group).permit(:id, :name, :address, :time,
     :picture, :twitter, :contact, :activities, :email, :level,
-    :founded_on, :join_as_coach, :full, :city, :country, :street, :zip)
+    :founded_on, :join_as_coach, :full, :city, :country, :street, :zip,
+    :learning_resources)
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -35,6 +35,8 @@ class Group < ActiveRecord::Base
   validates :name, presence: true
   validates :email, format: { with: FORMAT }, presence: true
   validates :contact, presence: true
+  validates :city, presence: true
+  validates :country, presence: true
 
   mount_uploader :picture, PictureUploader
   geocoded_by :location

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -6,14 +6,20 @@
       = f.label(:name, "Project group name *")
       = f.text_field :name, placeholder: 'Name of the group', class: 'form-control'
     .form-group
-      = f.label(:founded_on, "Founded on")
-      = f.text_field :founded_on, placeholder: 'When was your group founded?', class: 'form-control'
+      = f.label(:email, "Where we'll send official emails (only visible to us) *")
+      = f.text_field :email, placeholder: "email@address.com", class: 'form-control'
+    .form-group
+      = f.label(:contact, "Contact info (visible to everyone) *")
+      = f.text_area :contact, placeholder: 'How to contact your group', class: 'form-control'
     .form-group
       = f.label(:twitter, "Twitter handle")
       = f.text_field :twitter, placeholder: '@twitterhandle', class: 'form-control'
     .form-group
-      = label_tag(:activities, "Description (you can use markdown!)")
-      = f.text_area :activities, placeholder: 'Your activities, topics, projects', class: 'form-control'
+      = f.label(:founded_on, "Founded on")
+      = f.text_field :founded_on, placeholder: 'When was your group founded?', class: 'form-control'
+    .form-group
+      = f.label(:level, "Level of group")
+      = f.text_area :level, placeholder: 'Beginner, intermediate, advanced, all of the above?', class: 'form-control'
     .form-group
       = f.label(:picture, "Group picture")
       = f.file_field :picture, placeholder: 'What you look like'
@@ -25,30 +31,27 @@
       = f.text_field :time, placeholder: 'When you meet', class: 'form-control'
     .form-group
       = f.label(:address, "Meeting place")
-      = f.text_field :address, placeholder: 'Where you meet', class: 'form-control'
+      = f.text_field :address, placeholder: 'Office, company, etc...', class: 'form-control'
     .form-group
       = f.label(:street, "Street")
-      = f.text_field :street, placeholder: 'The name of the street', class: 'form-control'
+      = f.text_field :street, class: 'form-control'
     .form-group
       = f.label(:zip, "Zip Code")
-      = f.text_field :zip, placeholder: 'What\'s the zip code' , class: 'form-control'
+      = f.text_field :zip, class: 'form-control'
     .form-group
       = f.label(:city, "City *")
-      = f.text_field :city, placeholder: 'In what city', class: 'form-control'
+      = f.text_field :city, class: 'form-control'
     .form-group
       = f.label(:country, "Country *")
-      = f.country_select(:country, {priority_countries: ["DE", "PL", "IN", "US"], include_blank: true}, {class: 'form-control'})
-    
+      = f.country_select(:country, {priority_countries: ["DE", "PL", "IN", "US"], include_blank: true}, {class: 'form-control'})  
+
   .col-md-4
     .form-group
-      = f.label(:email, "Where we'll send official emails")
-      = f.text_field :email, placeholder: "email@address.com", class: 'form-control'
+      = label_tag(:activities, "Description (you can use markdown!)")
+      = f.text_area :activities, placeholder: 'Your activities, topics, projects', class: 'form-control'
     .form-group
-      = f.label(:contact, "Contact info *")
-      = f.text_area :contact, placeholder: 'How to contact your group', class: 'form-control'
-    .form-group
-      = f.label(:level, "Level of group")
-      = f.text_area :level, placeholder: 'Beginner, intermediate, advanced, all of the above?', class: 'form-control'
+      = f.label(:learning_resources, "Learning resources you find helpful, and which might interest others. Share the love!")
+      = f.text_area :learning_resources, placeholder: 'Hartl tutorial, codecademy, etc...', class: 'form-control'
     - if @group.new_record?
       .form-group
         = f.check_box :join_as_coach

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -87,12 +87,21 @@
             = link_to coach.first_name, person_path(coach)
             - if admin?
               = render partial: 'remove_from_group', locals: { object: coach, group: @group }
-    #group-map.col-md-4
-      - if @group.address?
-        .map
-          = groups_map @group
-      - else
-        = image_tag('follow_your_dreams.gif')
+
+    .col-md-4
+      #group-map
+        - if @group.address?
+          .map
+            = groups_map @group
+        - else
+          = image_tag('follow_your_dreams.gif')
+
+      - if @group.learning_resources?
+        %br
+        %p
+          %strong Suggested learning resources:
+          = markdown(@group.learning_resources)
+
 
   .row.topics
     = render template: "topics/index"

--- a/db/migrate/20150614105629_add_learning_resources_to_groups.rb
+++ b/db/migrate/20150614105629_add_learning_resources_to_groups.rb
@@ -1,0 +1,5 @@
+class AddLearningResourcesToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :learning_resources, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 20150614105629) do
     t.string   "picture"
     t.string   "twitter"
     t.text     "working_on"
-    t.boolean  "willing_to_coach"
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true
@@ -105,8 +104,8 @@ ActiveRecord::Schema.define(version: 20150614105629) do
     t.datetime "updated_at"
     t.integer  "person_id"
     t.boolean  "draft",        default: false, null: false
-    t.date     "published_on"
     t.string   "slug"
+    t.date     "published_on"
   end
 
   add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505182728) do
+ActiveRecord::Schema.define(version: 20150614105629) do
 
   create_table "friendly_id_slugs", force: true do |t|
     t.string   "slug",                      null: false
@@ -41,12 +41,13 @@ ActiveRecord::Schema.define(version: 20150505182728) do
     t.string   "email"
     t.string   "level"
     t.string   "founded_on"
-    t.boolean  "full",       default: false
+    t.boolean  "full",               default: false
     t.string   "city"
     t.string   "country"
     t.string   "zip"
     t.string   "street"
     t.string   "slug"
+    t.text     "learning_resources"
   end
 
   add_index "groups", ["slug"], name: "index_groups_on_slug", unique: true
@@ -82,6 +83,7 @@ ActiveRecord::Schema.define(version: 20150505182728) do
     t.string   "picture"
     t.string   "twitter"
     t.text     "working_on"
+    t.boolean  "willing_to_coach"
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true
@@ -102,9 +104,9 @@ ActiveRecord::Schema.define(version: 20150505182728) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "person_id"
-    t.string   "slug"
     t.boolean  "draft",        default: false, null: false
     t.date     "published_on"
+    t.string   "slug"
   end
 
   add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -6,7 +6,7 @@ describe GroupsController do
     let(:person) { create(:person) }
 
     context 'with correct params' do
-      let(:params) {{ group: { name: 'rubycorns', email: 'test@tehest.com', contact: 'fruitcakes' } }}
+      let(:params) {{ group: { name: 'rubycorns', email: 'test@tehest.com', contact: 'fruitcakes', city: 'Berlin', country: 'DE' } }}
 
       before do
         allow(controller).to receive :authenticate_person!

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -24,6 +24,8 @@ FactoryGirl.define do
     name 'Test Group'
     email 'testgroup@email.com'
     contact 'some googlegroup'
+    city 'Berlin'
+    country 'DE'
     slug 'test-group'
   end
 
@@ -31,6 +33,8 @@ FactoryGirl.define do
     name 'Second Group'
     email 'secondgroup@email.com'
     contact 'some other googlegroup'
+    city 'Hamburg'
+    country 'DE'
     slug 'second-group'
   end
 end

--- a/spec/features/group_create_spec.rb
+++ b/spec/features/group_create_spec.rb
@@ -14,6 +14,8 @@ feature 'create a group' do
     fill_in 'Project group name', with: 'Testgroup'
     fill_in 'Where we\'ll send official emails', with: 'test@email.com'
     fill_in 'Contact info', with: 'this googlegroup'
+    fill_in 'City', with: 'Berlin'
+    select('Germany', from: 'Country', match: :first) # selects the first Germany from dropdown (there are two b/c one is a preferred country at the top)
     expect(page).to have_content('Join group as coach')
     check 'Join group as coach'
     expect(page).to_not have_content('Is your group full?')
@@ -39,6 +41,8 @@ feature 'create a group' do
     fill_in 'Project group name', with: 'Testgroup'
     fill_in 'Where we\'ll send official emails', with: 'test@email.com'
     fill_in 'Contact info', with: 'this googlegroup'
+    fill_in 'City', with: 'Berlin'
+    select('Germany', from: 'Country', match: :first)
     expect(page).to have_content('Join group as coach')
     click_button 'Create Group'
 


### PR DESCRIPTION
This closes issue #339

Along the way, I also re-arranged the order of fields in the groups form. I think before we were just adding whatever new field to the end of the form, so things were a bit mixed up. I think it makes more sense now, but let me know if I'm way off base. 

I also added some text to clarify the difference between the email field and the contact field.

I also noticed that the form made it look as though city & country are required (they had *'s beside them). This however was not the case for realz. I added validations to these two fields & fixed the tests. Was there a reason why we were presenting them like they were required but weren't actually making them required?

I think once this is merged we should send an email to all groups asking them to update their information. 
