### PR TITLE
Step 1: use admin boolean instead of role class

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -4,15 +4,14 @@ class AdminsController < ApplicationController
   before_action :ensure_admin_powers
 
   def create
-    person = Person.find(params[:admin])
-    person.add_role(:admin)
+    person = Person.find(params[:id])
+    person.update_attribute(:admin, true)
     redirect_to dashboard_path, notice: "Successfully adminified #{person}"
   end
 
   def destroy
-    person = Person.find(params[:person][:admin_id])
-    person.remove_role(:admin)
+    person = Person.find(params[:id])
+    person.update_attribute(:admin, false)
     redirect_to dashboard_path, notice: "Successfully un-adminified #{person}"
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
       :picture,
       :working_on,
       :workshop_coach,
+      :admin
     ]
 
     devise_parameter_sanitizer.for(:sign_up) do |person|
@@ -28,7 +29,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_admin_powers
-    render_403 unless current_person.has_role?(:admin)
+    render_403 unless current_person.admin?
   end
 
   def ensure_member_powers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
       :picture,
       :working_on,
       :workshop_coach,
-      :admin
+      :admin,
     ]
 
     devise_parameter_sanitizer.for(:sign_up) do |person|

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,12 +4,11 @@ class DashboardsController < ApplicationController
   before_action :ensure_admin_powers
 
   def show
-    @admins, @non_admins = Person.all.partition { |person| person.has_role?(:admin) }
+    @admins, @non_admins = Person.all.partition { |person| person.admin? }
     @non_admins.sort!
     @admins.sort!
     @published_posts = Post.published
     @unpublished_posts = Post.draft
     @groups = Group.all
   end
-
 end

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -4,7 +4,7 @@ module PeopleHelper
   end
 
   def admin?
-     person_signed_in? && current_person.has_role?('admin')
+     person_signed_in? && current_person.admin?
   end
 
   def person_avatar(person)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -61,7 +61,7 @@ class Group < ActiveRecord::Base
   end
 
   def deletable_by?(person)
-    person && person.has_role?(:admin)
+    person && person.admin?
   end
 
   def not_full?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,9 +41,7 @@ class Person < ActiveRecord::Base
 
   validates :first_name, presence: true
 
-  def self.admin
-    joins(:roles).where('roles.name = \'admin\'')
-  end
+  scope :admin, -> { where(admin: true) }
 
   def has_group?
     groups.empty? == false

--- a/app/views/dashboards/show.html.haml
+++ b/app/views/dashboards/show.html.haml
@@ -18,10 +18,12 @@
                   = f.hidden_field :admin_id, value: admin.id
                   %button.link.no-btn
                     %span= fa_icon "magic", text: "un-adminify"
+
           - if @non_admins.length > 0
-            = form_tag dashboard_admins_path, method: 'POST' do
+            = form_tag dashboard_admins_path, method: 'create' do
               .dashboard-left
-                = select_tag 'admin', options_from_collection_for_select(@non_admins, :id, :name), class: 'form-control'
+                = select_tag 'id', options_from_collection_for_select(@non_admins, :id, :name), class: 'form-control'
+
               .dashboard-right
                 %button.btn.btn-primary{ name: "submit"}= fa_icon "magic", text: "adminify"
           - else

--- a/app/views/dashboards/show.html.haml
+++ b/app/views/dashboards/show.html.haml
@@ -20,7 +20,7 @@
                     %span= fa_icon "magic", text: "un-adminify"
 
           - if @non_admins.length > 0
-            = form_tag dashboard_admins_path, method: 'create' do
+            = form_tag dashboard_admins_path, method: 'post' do
               .dashboard-left
                 = select_tag 'id', options_from_collection_for_select(@non_admins, :id, :name), class: 'form-control'
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
               <ul class="dropdown-menu " role="menu">
                 <li><%= link_to current_person.full_name, current_person %></li>
                 <li><%= link_to "logout", destroy_person_session_path, method: :delete %></li>
-                <% if current_person.has_role?('admin') %>
+                <% if current_person.admin? %>
                   <li role="presentation" class="divider"></li>
                   <li><%= link_to 'Admin dashboard', dashboard_path %></li>
                 <% end %>

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -1,6 +1,6 @@
 %article.post
   %header
-    - if current_person && current_person.has_role?(:admin) && post.draft?
+    - if current_person && current_person.admin? && post.draft?
       %p.pull-right= fa_icon "file-o", text: "it's a draft"
     %h2= link_to "#{post.try(:title)}", post_path(post)
     %p.post-meta

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -9,7 +9,7 @@
       - else
         .latest-post-overview
           Oops, no blogposts here
-      = link_to 'New Post', new_post_path if current_person && current_person.has_role?(:admin)
+      = link_to 'New Post', new_post_path if current_person && current_person.admin?
     %aside.col-sm-4
       .twitter-feed
         %a.twitter-timeline{"data-widget-id" => "467588755692322816", href: "https://twitter.com/rubycorns"} Tweets by @rubycorns

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -4,7 +4,7 @@
       %h1.page-header Corporate Blog
       = render partial: 'post', object: @post
       #post-edit-delete-buttons
-        - if current_person && current_person.has_role?(:admin)
+        - if current_person && current_person.admin?
           = link_to 'edit', edit_post_path(@post)
           |
           \#{link_to 'delete', @post, method: :delete, data: {confirm: 'Are you sure?'}}

--- a/db/migrate/20150719091734_add_admin_to_people.rb
+++ b/db/migrate/20150719091734_add_admin_to_people.rb
@@ -1,0 +1,5 @@
+class AddAdminToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630183729) do
+ActiveRecord::Schema.define(version: 20150719091734) do
 
   create_table "friendly_id_slugs", force: true do |t|
     t.string   "slug",                      null: false
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20150630183729) do
   add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
   add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
   add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
-
 
   create_table "groups", force: true do |t|
     t.string   "name"
@@ -51,6 +50,8 @@ ActiveRecord::Schema.define(version: 20150630183729) do
     t.text     "learning_resources"
   end
 
+  add_index "groups", ["slug"], name: "index_groups_on_slug", unique: true
+
   create_table "memberships", force: true do |t|
     t.integer  "group_id"
     t.integer  "person_id"
@@ -66,15 +67,15 @@ ActiveRecord::Schema.define(version: 20150630183729) do
   create_table "people", force: true do |t|
     t.string   "first_name"
     t.string   "last_name"
-    t.string   "email",                  default: "", null: false
+    t.string   "email",                  default: "",    null: false
     t.integer  "group_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -83,6 +84,7 @@ ActiveRecord::Schema.define(version: 20150630183729) do
     t.string   "twitter"
     t.text     "working_on"
     t.boolean  "workshop_coach"
+    t.boolean  "admin",                  default: false
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true
@@ -107,6 +109,8 @@ ActiveRecord::Schema.define(version: 20150630183729) do
     t.string   "slug"
     t.date     "published_on"
   end
+
+  add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true
 
   create_table "roles", force: true do |t|
     t.string   "name"

--- a/lib/tasks/set_admin_role.rake
+++ b/lib/tasks/set_admin_role.rake
@@ -1,0 +1,11 @@
+task set_admin_role: :environment do
+  puts "finding admins"
+  people = Person.with_role(:admin)
+
+  puts 'setting the admin boolean'
+  people.map do |person|
+    person.update_attribute(:admin, true)
+  end
+
+  puts 'done! have some cake'
+end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 describe AdminsController do
 
-  let(:person) { create(:person) }
-  let(:admin) { create(:second_person) }
+  let(:person) { create :person }
+  let(:admin) { create :admin }
   before :each do
-    admin.add_role(:admin)
-    admin.save
     allow(controller).to receive :authenticate_person!
     allow(controller).to receive(:current_person).and_return(admin)
   end
@@ -14,25 +12,21 @@ describe AdminsController do
   describe 'create' do
 
     it 'is not allowed for normal users' do
-      admin.remove_role(:admin)
-      admin.save
-      post :create, admin: person.id
-      expect(person).not_to have_role(:admin)
+      post :create, id: person.id
+      expect(person.admin?).to be false
     end
 
-    it 'gives admin powers to a user' do
-      post :create, admin: person.id
-      expect(person).to have_role(:admin)
+    it 'gives admin powers to an admin user' do
+      post :create, id: admin.id
+      expect(admin.admin?).to be true
     end
   end
 
   describe 'destroy' do
 
     it 'removes admin power from a user' do
-      person.add_role(:admin)
-      person.save
-      delete :destroy, person: { admin_id: person.id }, id: person.id
-      expect(person).to_not have_role(:admin)
+      delete :destroy, id: admin.id
+      expect(admin.reload.admin?).to be false
     end
   end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -121,7 +121,7 @@ describe GroupsController do
     context 'as an admin' do
 
       before do
-        person.add_role :admin
+        person.admin = true
       end
 
       it 'redirects to the groups path after successful deletion' do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -60,8 +60,7 @@ describe PostsController do
       context 'as an admin' do
 
         before do
-          person.add_role :admin
-          person.save
+          person.admin = true
         end
 
         context 'publishing the post' do
@@ -143,8 +142,7 @@ describe PostsController do
     context 'as an admin' do
 
       before do
-        person.add_role :admin
-        person.save
+        person.admin = true
         allow(Post).to receive(:find).and_return(post)
       end
 

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -49,8 +49,6 @@ FactoryGirl.define do
     last_name 'Cake'
     email
     password 'tarntest'
-    after(:build) do |user|
-      user.add_role(:admin)
-    end
+    admin true
   end
 end

--- a/spec/features/admin_remove_person_spec.rb
+++ b/spec/features/admin_remove_person_spec.rb
@@ -23,7 +23,7 @@ feature 'Remove a person from a group' do
   context 'the admin' do
 
     before do
-      person.add_role 'admin'
+      person.update_attribute(:admin, true)
       person.join!(group, 'StudentMembership')
       go_to_group_page
     end

--- a/spec/features/blog_draft_spec.rb
+++ b/spec/features/blog_draft_spec.rb
@@ -12,8 +12,7 @@ feature 'Blog drafts' do
   end
 
   def login_as_admin
-    person = create(:person)
-    person.add_role(:admin)
+    person =  create(:admin)
     visit new_person_session_path
     sign_in person
   end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -26,11 +26,10 @@ describe 'Admin dashboard', :type => :feature do
   end
 
   context 'the user is logged in as admin' do
-    let!(:person) { create(:person) }
+    let!(:person) { create(:admin) }
     let!(:person2) { create(:person, first_name: 'Person', last_name: '2') }
 
     before do
-      person.add_role :admin
       visit new_person_session_path
       sign_in person
     end
@@ -69,10 +68,6 @@ describe 'Admin dashboard', :type => :feature do
         expect(page).to_not have_selector 'li a', text: 'Person 2'
       end
       expect(page).to have_content 'Successfully un-adminified Person 2'
-
     end
-
   end
-
-
 end

--- a/spec/features/group_delete_spec.rb
+++ b/spec/features/group_delete_spec.rb
@@ -21,7 +21,7 @@ feature 'admins can delete groups' do
     end
 
     scenario 'admin deletes a group' do
-      person.add_role :admin
+      person.update_attribute(:admin, true)
       user_visits_group_page
       user_deletes_group
       group_has_been_deleted

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -57,7 +57,7 @@ describe Group do
     end
 
     it 'is deletable by an admin' do
-      person.add_role :admin
+      person.update_attribute(:admin, true)
       expect(group).to be_deletable_by person
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -112,14 +112,11 @@ describe Person do
     end
   end
 
-
   describe '.admin' do
-
     subject { described_class.admin }
 
-    let!(:admin) { create(:person) }
+    let!(:admin) { create(:admin) }
     let!(:user) { create(:person) }
-    before { admin.add_role :admin }
 
     it 'lists all the admins' do
       expect(subject).to contain_exactly(admin)

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -16,25 +16,25 @@ describe Role do
   let(:person) { create(:person) }
 
   it 'does not assign a role to a newly created user' do
-    expect(person.has_role?(:admin)).to be_falsey
+    expect(person.admin?).to be_falsey
   end
 
   describe 'adding a role' do
-    before { person.add_role(:admin) }
+    before { person.admin = true }
 
     it 'assigns the user an admin role' do
-      expect(person.has_role?(:admin)).to be_truthy
+      expect(person.admin?).to be_truthy
     end
   end
 
   describe 'removing a role' do
     before do
-      person.add_role(:admin)
-      person.remove_role(:admin)
+      person.admin = true
+      person.admin = false
     end
 
     it 'removes the admin role from the person' do
-      expect(person.has_role?(:admin)).to be_falsey
+      expect(person.admin?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
I think that [rolify](https://github.com/RolifyCommunity/rolify) is a bit too much for our little app... we only have one role. I initially implemented rolify b/c I was using it at work, but I think that maybe just an `admin` boolean is the way to go. 

This is step one: add the admin boolean & use it
Step 2 will be in a separate PR to remove the role class. I assume it can be merged and deployed one the [rake task](https://github.com/rubycorns/rorganize.it/blob/add-role-boolean-to-people/lib/tasks/set_admin_role.rake) from step one has been run. 