### PR TITLE
get lots of info for coaches page

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -30,6 +30,6 @@ class PeopleController < ApplicationController
 
   def person_params
     params.require(:person).permit(:first_name, :last_name, :email, 
-    :picture, :twitter, :working_on, :workshop_coach)
+    :picture, :twitter, :working_on, :workshop_coach, :city, :country, :willing_to_travel)
   end
 end

--- a/app/views/coaches/index.html.haml
+++ b/app/views/coaches/index.html.haml
@@ -1,6 +1,23 @@
 .container
-  %h1.page-header
+  %h1
     This is a coach list
+  %p
+    More specifically, it is a list of people who are willing to coach at Rails Girls workshops. If you are a Rails Girls organizer in need of coaches, please 
+    %a{ href: "mailto:roar@rorganize.it" } contact us,
+    and we will send you a list.
+
+  - if logged_in?(current_person)
+    %p
+      If you are interested in becoming a Rails Girls coach fill in the relevant info on your 
+      %a{ href: edit_person_path(current_person) } profile page. 
+      The world will love you for it!
+  - else
+    %p
+      If you are interested in becoming a Rails Girls coach
+      %a{ href: new_person_registration_path } sign up to the app, 
+      and then fill in the relevant info on your profile page.
+
+  %hr
   .row
     .col-md-8
       %ul.list-group

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -38,7 +38,7 @@
 
       .form-group
         = f.check_box(:workshop_coach)
-        = label_tag(:person_workshop_coach, "I am willing to COACH at Rails Girls Workshops")
+        = label_tag(:person_workshop_coach, "I am willing to COACH at Rails Girls workshops")
 
       .form-group
         = f.check_box(:willing_to_travel)

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -2,7 +2,7 @@
   = form_for(@person, html: { multipart: true }) do |f|
     = render 'shared/error_messages', object: f.object
 
-    .col-md-6
+    .col-md-5
       .form-group
         = label_tag(:first_name, "Your first name *")
         = f.text_field :first_name, placeholder: 'First name', class: 'form-control'
@@ -13,17 +13,46 @@
         = label_tag(:twitter, "Your twitter handle")
         = f.text_field :twitter, placeholder: '@twitterhandle', class: 'form-control'
       .form-group
-        = f.check_box(:workshop_coach)
-        = label_tag(:person_workshop_coach, "I am willing to coach at Rails Girls Workshops")
-      .form-group
         = label_tag(:picture, "Add your profile picture")
         = f.file_field :picture, placeholder: 'picture'
         %p.help-block Choose your profile picture
-
-    .col-md-6
       .form-group
         = label_tag(:working_on, "What are you working on? (you can use markdown!)")
         = f.text_area :working_on, placeholder: 'tutorials? a cool app?', class: 'form-control', rows: 5, id: 'working-on'
+
+    .col-md-1
+
+    .col-md-5
+      %h3 Are you willing to coach at a Rails Girls workshop?
+      %br
+      %p What does this mean?
+      %ul
+        %li You may be contacted by Rails Girls organizers about coaching at various workshops
+        %li We will share your email address with trusted organizers
+        %li 
+          Your name will be displayed on our 
+          %a{ href: coaches_path } coaches index page. 
+        %li Everyone will think you're really really awesome. And most importantly, you will be.
+      %br
+      %p Convinced? That's great. We just need a few things from you,
+
+      .form-group
+        = f.check_box(:workshop_coach)
+        = label_tag(:person_workshop_coach, "I am willing to COACH at Rails Girls Workshops")
+
+      .form-group
+        = f.check_box(:willing_to_travel)
+        = label_tag(:willing_to_travel, "I am willing to TRAVEL to Rails Girls workshops")
+      
+      .form-group
+        = label_tag(:city, "City")
+        = f.text_field :city, placeholder: 'Rubycity', class: 'form-control'
+
+      .form-group
+        = f.label(:country, "Country")
+        = f.country_select(:country, {priority_countries: ["DE", "PL", "IN", "US"], include_blank: true}, {class: 'form-control'})
+
+      %p.help-block (Knowing where you live will help organizers find the best coaches for their workshops)
 
       .form-group
         = f.submit "Save", class: 'btn btn-primary'

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -1,5 +1,3 @@
 .container
-  .row
-    .col-md-12
-      %h2 Edit Profile
+  %br
   = render 'form'

--- a/db/migrate/20150825174702_add_willing_to_travel_to_people.rb
+++ b/db/migrate/20150825174702_add_willing_to_travel_to_people.rb
@@ -1,0 +1,5 @@
+class AddWillingToTravelToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :willing_to_travel, :boolean, default: false
+  end
+end

--- a/db/migrate/20150825180539_add_city_to_people.rb
+++ b/db/migrate/20150825180539_add_city_to_people.rb
@@ -1,0 +1,5 @@
+class AddCityToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :city, :string
+  end
+end

--- a/db/migrate/20150825181332_add_country_to_people.rb
+++ b/db/migrate/20150825181332_add_country_to_people.rb
@@ -1,0 +1,5 @@
+class AddCountryToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150804191714) do
+ActiveRecord::Schema.define(version: 20150825181332) do
 
   create_table "friendly_id_slugs", force: true do |t|
     t.string   "slug",                      null: false
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 20150804191714) do
     t.boolean  "inactive",           default: false
   end
 
+  add_index "groups", ["slug"], name: "index_groups_on_slug", unique: true
+
   create_table "memberships", force: true do |t|
     t.integer  "group_id"
     t.integer  "person_id"
@@ -84,6 +86,9 @@ ActiveRecord::Schema.define(version: 20150804191714) do
     t.text     "working_on"
     t.boolean  "workshop_coach"
     t.boolean  "admin",                  default: false, null: false
+    t.boolean  "willing_to_travel",      default: false
+    t.string   "city"
+    t.string   "country"
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true
@@ -101,6 +106,8 @@ ActiveRecord::Schema.define(version: 20150804191714) do
     t.string   "slug"
     t.date     "published_on"
   end
+
+  add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true
 
   create_table "topics", force: true do |t|
     t.text     "body"

--- a/spec/features/edit_person_spec.rb
+++ b/spec/features/edit_person_spec.rb
@@ -10,7 +10,7 @@ feature 'edit a person' do
   before do
     visit person_path(person)
     click_link 'edit'
-    expect(page).to have_content('Edit Profile')
+    expect(page).to have_content('Your first name')
   end
 
   describe 'changing the working on section ' do


### PR DESCRIPTION
This PR adds:

* willing to travel checkbox
* city field
* country field

to user. 

It also explains a bit about what the Rails Girls Coaches feature is, and what it means to click all these boxes. 

Adding city & country will help us/organizers filter the coaches better.

Til and I also discussed a bit what to do about email addresses: we decided not to display the email addresses of users, and instead if a Rails Girls organizer wants to USE our coach list, they have to contact us and prove that they are trustworthy, and then we will send the email addresses to them. I think this is cool for now and can totes be expanded upon in the future if need be. 