### PR TITLE
adds coach location on profile page if it exists

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -23,4 +23,10 @@ module PeopleHelper
     end
   end
 
+  def coach_location?(person)
+    if person.city? || person.country?
+      true
+    end
+  end
+
 end

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -21,6 +21,13 @@
       - if @person.workshop_coach?
         %p
           I am willing to coach at Rails Girls workshops
+      - if @person.willing_to_travel?
+        %p
+          I am willing to travel to a Rails Girls Workshop
+      - if coach_location?(@person)
+        %p
+          %strong Based in:
+          #{@person.city} #{@person.country}
     .col-md-4
       %h4 Project Groups:
       - if @person.has_group?


### PR DESCRIPTION
@BriocheBerlin and @berlintam also worked on this. 
fixes #373
We just updated the people/show view to display if the person has opted to be a coach and if they have specified a location we will display that too.