### PR TITLE
merge user & github accounts via profile

### DIFF
--- a/app/assets/stylesheets/custom/_groups_people.scss
+++ b/app/assets/stylesheets/custom/_groups_people.scss
@@ -62,3 +62,7 @@
 .topics {
   margin-top: 1em;
 }
+
+.button-class {
+  margin-top: 110px;
+}

--- a/app/assets/stylesheets/custom/_people.scss
+++ b/app/assets/stylesheets/custom/_people.scss
@@ -1,0 +1,4 @@
+.link-with-github {
+  padding-right: 2%;
+  padding-top: 0.5em;
+}

--- a/app/assets/stylesheets/custom/custom.css.scss
+++ b/app/assets/stylesheets/custom/custom.css.scss
@@ -9,7 +9,7 @@
 @import "_posts.scss";
 @import "_groups_people.scss";
 @import "_welcome.scss";
-
+@import "_people.scss";
 
 .section {
   padding: 3em 0;

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -3,15 +3,15 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def github
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @person = Person.from_omniauth(request.env["omniauth.auth"])
-    rorganize_person = Person.where(email: @person.email).where(provider: nil).first
+    rorganize_person = Person.find_by(email: @person.email, provider: nil)
 
     if rorganize_person.present?
       rorganize_person.merge_with_github!(@person)
       redirect_to rorganize_person
-      set_flash_message(:notice, :success, kind: "Github") if is_navigational_format?
+      set_flash_message(:notice, :success, kind: "GitHub") if is_navigational_format?
     elsif @person.persisted?
       sign_in_and_redirect @person, event: :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, kind: "Github") if is_navigational_format?
+      set_flash_message(:notice, :success, kind: "GitHub") if is_navigational_format?
     else
       session["devise.github_data"] = request.env["omniauth.auth"]
       redirect_to new_person_registration_url

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -3,8 +3,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def github
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @person = Person.from_omniauth(request.env["omniauth.auth"])
+    rorganize_person = Person.where(email: @person.email).where(provider: nil).first
 
-    if @person.persisted?
+    if rorganize_person.present?
+      rorganize_person.merge_with_github!(@person)
+      redirect_to rorganize_person
+      set_flash_message(:notice, :success, kind: "Github") if is_navigational_format?
+    elsif @person.persisted?
       sign_in_and_redirect @person, event: :authentication #this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "Github") if is_navigational_format?
     else
@@ -12,4 +17,5 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_person_registration_url
     end
   end
+
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -54,7 +54,7 @@ class Person < ActiveRecord::Base
   def merge_with_github!(github_person)
     self.provider = github_person.provider
     self.uid = github_person.uid
-    self.save
+    self.save!
   end
 
   def has_group?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -51,6 +51,12 @@ class Person < ActiveRecord::Base
     end
   end
 
+  def merge_with_github!(github_person)
+    self.provider = github_person.provider
+    self.uid = github_person.uid
+    self.save
+  end
+
   def has_group?
     groups.empty? == false
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
           <ul class="nav navbar-nav navbar-right profile-header">
             <li><%= link_to 'Sign in', new_person_session_path %></li>
             <li><%= link_to 'Sign up', new_person_registration_path %></li>
-            <li><%= link_to "Sign in with Github", person_omniauth_authorize_path(:github) %></li>
+            <li><%= link_to "Sign in with GitHub", person_omniauth_authorize_path(:github) %></li>
           </ul>
           <% end %>
           <ul class="nav navbar-nav">

--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -17,7 +17,7 @@
 
     %p
       The code is open source. Check it out and contribute on
-      = link_to(fa_icon("github", text: "Github"), "//github.com/rubycorns/RailsGirlsApp")
+      = link_to(fa_icon("github", text: "GitHub"), "//github.com/rubycorns/RailsGirlsApp")
     %p
       And we proudly host on Shelly Cloud.
 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -5,6 +5,7 @@
         %h1.pull-left= @person.full_name
         .btn-group.pull-right
           - if logged_in?(@person)
+            = link_to "Link account with Github", person_omniauth_authorize_path(:github), class: 'btn btn-custom', id: 'github-button' unless @person.provider.present?
             = link_to edit_person_path(@person), class: 'btn btn-default' do
               = fa_icon "pencil", text: "edit"
           = link_to people_path, class: 'btn btn-default' do
@@ -44,6 +45,7 @@
         %p
           = @person.first_name
           is not in a group.
+
     #working-on.col-md-5
       - if @person.working_on?
         %h4 Working on

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -3,13 +3,21 @@
     .col-md-12
       .page-header.clearfix
         %h1.pull-left= @person.full_name
-        .btn-group.pull-right
-          - if logged_in?(@person)
-            = link_to "Link account with Github", person_omniauth_authorize_path(:github), class: 'btn btn-custom', id: 'github-button' unless @person.provider.present?
+        - if logged_in?(@person)
+          .btn-group.pull-right
             = link_to edit_person_path(@person), class: 'btn btn-default' do
               = fa_icon "pencil", text: "edit"
-          = link_to people_path, class: 'btn btn-default' do
-            = fa_icon "arrow-left", text: "back"
+            = link_to people_path, class: 'btn btn-default' do
+              = fa_icon "arrow-left", text: "back"
+          .link-with-github.pull-right
+            - if @person.provider.present?
+              = fa_icon("github", text: "Linked with Github")
+            - else
+              = link_to "Link account with Github", person_omniauth_authorize_path(:github), id: 'github-button'
+        - else
+          .btn-group.pull-right
+            = link_to people_path, class: 'btn btn-default' do
+              = fa_icon "arrow-left", text: "back"
 
   .row
     .col-md-3

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -11,9 +11,9 @@
               = fa_icon "arrow-left", text: "back"
           .link-with-github.pull-right
             - if @person.provider.present?
-              = fa_icon("github", text: "Linked with Github")
+              = fa_icon("github", text: "Linked with GitHub")
             - else
-              = link_to "Link account with Github", person_omniauth_authorize_path(:github), id: 'github-button'
+              = link_to "Link account with GitHub", person_omniauth_authorize_path(:github), id: 'github-button'
         - else
           .btn-group.pull-right
             = link_to people_path, class: 'btn btn-default' do

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -38,7 +38,6 @@ describe 'Signing in', :type => :feature do
   end
 
   context 'with github' do
-    let!(:person) { create(:person, provider: 'github', uid: '1234567') }
 
     before(:each) do
       # https://github.com/intridea/omniauth/wiki/Integration-Testing#omniauthconfigadd_mock
@@ -51,7 +50,7 @@ describe 'Signing in', :type => :feature do
           nickname: "Willow",
           email: "willow.rosenberg@example.com",
           name: "Willow Rosenberg",
-          image: "cake.jpg"
+          image: ""
         }
       )
     end
@@ -64,5 +63,36 @@ describe 'Signing in', :type => :feature do
     it 'successfully signs in the user via github' do
       expect(page).to have_content("Successfully authenticated from Github account")
     end
+  end
+
+  context 'merging an account with github' do
+    let!(:person) { create(:person, email: 'cordelia.chase@example.com', first_name: 'Cordelia', provider: nil) }
+
+    before(:each) do
+      OmniAuth.config.test_mode = true
+
+      OmniAuth.config.add_mock(:github, 
+        provider: "github",
+        uid: "7654321",
+        info: {
+          nickname: "Cordelia",
+          email: "cordelia.chase@example.com",
+          name: "Cordelia Chase",
+          image: ""
+        }
+      )
+    end
+
+    before do
+      sign_in person
+      visit person_path(person)
+      find("#github-button").click
+    end
+
+    it 'successfully merges the users accound with github' do
+      expect(page).to have_content("Successfully authenticated from Github account")
+      expect(page).to_not have_content("Link with Github")
+    end
+
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -83,7 +83,7 @@ describe 'Signing in', :type => :feature do
       )
     end
 
-    it 'successfully merges the users accound with github' do
+    it 'successfully merges the users account with github' do
       sign_in person
       visit person_path(person)
       find("#github-button").click

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -91,7 +91,8 @@ describe 'Signing in', :type => :feature do
 
     it 'successfully merges the users accound with github' do
       expect(page).to have_content("Successfully authenticated from Github account")
-      expect(page).to_not have_content("Link with Github")
+      expect(page).to_not have_content("Link account with Github")
+      expect(page).to have_content("Linked with Github")
     end
 
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -57,11 +57,11 @@ describe 'Signing in', :type => :feature do
 
     before do
       visit root_path
-      click_link "Sign in with Github"
+      click_link "Sign in with GitHub"
     end
 
     it 'successfully signs in the user via github' do
-      expect(page).to have_content("Successfully authenticated from Github account")
+      expect(page).to have_content("Successfully authenticated from GitHub account")
     end
   end
 
@@ -83,16 +83,14 @@ describe 'Signing in', :type => :feature do
       )
     end
 
-    before do
+    it 'successfully merges the users accound with github' do
       sign_in person
       visit person_path(person)
       find("#github-button").click
-    end
 
-    it 'successfully merges the users accound with github' do
-      expect(page).to have_content("Successfully authenticated from Github account")
-      expect(page).to_not have_content("Link account with Github")
-      expect(page).to have_content("Linked with Github")
+      expect(page).to have_content("Successfully authenticated from GitHub account")
+      expect(page).to_not have_content("Link account with GitHub")
+      expect(page).to have_content("Linked with GitHub")
     end
 
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -146,4 +146,16 @@ describe Person do
     end
   end
 
+  describe '#merge_with_github!' do
+    let(:github_person) { build :person, provider: 'github', uid: '123456' }
+    let(:person) { build :second_person }
+
+    before { person.merge_with_github!(github_person)}
+
+    it 'merges the rorganize person with a github person' do
+      expect(person.reload.provider).to eql 'github'
+      expect(person.reload.uid).to eql '123456'
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -150,9 +150,8 @@ describe Person do
     let(:github_person) { build :person, provider: 'github', uid: '123456' }
     let(:person) { build :second_person }
 
-    before { person.merge_with_github!(github_person)}
-
     it 'merges the rorganize person with a github person' do
+      person.merge_with_github!(github_person)
       expect(person.reload.provider).to eql 'github'
       expect(person.reload.uid).to eql '123456'
     end


### PR DESCRIPTION
closes #382 like a boss. 

There's now a link on someone's profile page (if they're logged in and if they're not yet merged w/ github) offering a person an opportunity to link their rorganize account with their github account. 

If they click on this button, they will be able to login with github in da future. 

woot. Check it @PragTob :smile: 