### PR TITLE
(WIP) Enable adding website to profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Run the server
 
 et voilá
 
+Run all the tests 
+
+    bundle exec rspec
 
 
 ### Git: branches 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -34,6 +34,6 @@ class PeopleController < ApplicationController
 
   def person_params
     params.require(:person).permit(:first_name, :last_name, :email,
-    :picture, :twitter, :working_on, :workshop_coach, :city, :country, :willing_to_travel)
+    :picture, :twitter, :website, :working_on, :workshop_coach, :city, :country, :willing_to_travel)
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,6 +40,8 @@ class Person < ActiveRecord::Base
 
   validates :first_name, presence: true
 
+  before_validation :prepend_http
+
   scope :admin, -> { where(admin: true) }
   scope :by_country, -> (country) { where(country: country) }
   scope :by_city, -> (city) { where(city: city) }
@@ -113,4 +115,14 @@ class Person < ActiveRecord::Base
     name <=> other.name
   end
 
+  private
+    def prepend_http
+      if website.present?
+        website.prepend("http://") unless website_has_protocol?
+      end
+    end
+
+    def website_has_protocol?
+      !!(website =~ %r{\Ahttp://|\Ahttps://|\A//})
+    end
 end

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -4,20 +4,23 @@
 
     .col-md-5
       .form-group
-        = label_tag(:first_name, "Your first name *")
+        = f.label(:first_name, "Your first name *")
         = f.text_field :first_name, placeholder: 'First name', class: 'form-control'
       .form-group
-        = label_tag(:last_name, "Your last name")
+        = f.label(:last_name, "Your last name")
         = f.text_field :last_name, placeholder: 'Last name', class: 'form-control'
       .form-group
-        = label_tag(:twitter, "Your twitter handle")
+        = f.label(:twitter, "Your twitter handle")
         = f.text_field :twitter, placeholder: '@twitterhandle', class: 'form-control'
       .form-group
-        = label_tag(:picture, "Add your profile picture")
+        = f.label(:website, "Website")
+        = f.text_field :website, placeholder: 'http://example.me', class: 'form-control'
+      .form-group
+        = f.label(:picture, "Add your profile picture")
         = f.file_field :picture, placeholder: 'picture'
         %p.help-block Choose your profile picture
       .form-group
-        = label_tag(:working_on, "What are you working on? (you can use markdown!)")
+        = f.label(:working_on, "What are you working on? (you can use markdown!)")
         = f.text_area :working_on, placeholder: 'tutorials? a cool app?', class: 'form-control', rows: 5, id: 'working-on'
 
     .col-md-1
@@ -38,14 +41,14 @@
 
       .form-group
         = f.check_box(:workshop_coach)
-        = label_tag(:person_workshop_coach, "I am willing to COACH at Rails Girls workshops")
+        = f.label(:person_workshop_coach, "I am willing to COACH at Rails Girls workshops")
 
       .form-group
         = f.check_box(:willing_to_travel)
-        = label_tag(:willing_to_travel, "I am willing to TRAVEL to Rails Girls workshops")
+        = f.label(:willing_to_travel, "I am willing to TRAVEL to Rails Girls workshops")
       
       .form-group
-        = label_tag(:city, "City")
+        = f.label(:city, "City")
         = f.text_field :city, placeholder: 'Rubycity', class: 'form-control'
 
       .form-group

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -27,6 +27,10 @@
         %p
           Twitter:
           = render partial: "shared/twitter", locals: { object: @person }
+      - if @person.website?
+        %p
+          Website:
+          = render partial: "shared/website", locals: { object: @person }
       - if @person.workshop_coach?
         %p
           I am willing to coach at Rails Girls workshops

--- a/app/views/shared/_website.html.haml
+++ b/app/views/shared/_website.html.haml
@@ -1,0 +1,2 @@
+- if object.website?
+  = link_to object.website, object.website, html_options = { target: '_blank'}

--- a/db/migrate/20151006193254_add_website_to_people.rb
+++ b/db/migrate/20151006193254_add_website_to_people.rb
@@ -1,0 +1,5 @@
+class AddWebsiteToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,11 +86,12 @@ ActiveRecord::Schema.define(version: 20151013180304) do
     t.text     "working_on"
     t.boolean  "workshop_coach"
     t.boolean  "admin",                  default: false, null: false
+    t.string   "provider"
+    t.string   "uid"
     t.boolean  "willing_to_travel",      default: false
     t.string   "city"
     t.string   "country"
-    t.string   "provider"
-    t.string   "uid"
+    t.string   "website"
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true

--- a/spec/features/edit_person_spec.rb
+++ b/spec/features/edit_person_spec.rb
@@ -20,19 +20,34 @@ feature 'edit a person' do
       click_button 'Save'
     end
 
-    it 'displays a successful alert message' do
+    scenario 'displays a successful alert message' do
       expect(page.text).to have_content "You updated your profile!"
     end
 
-    it 'redirects to the correct path' do
+    scenario 'redirects to the correct path' do
       expect(current_path).to eq person_path(person)
     end
 
-    it 'updates the correct information' do
+    scenario 'updates the correct information' do
       within('#working-on') do
         expect(page).to have_content 'capybara, rspec, css'
       end
     end
 
+  end
+
+  describe 'adding a valid personal website' do
+
+    scenario 'with complete link' do
+      fill_in "Website", with: 'http://pragtob.info'
+      click_button 'Save'
+      expect(page).to have_content 'http://pragtob.info'
+    end
+
+    scenario 'with incomplete link' do
+      fill_in "Website", with: 'malweene.com'
+      click_button 'Save'
+      expect(page).to have_content 'http://malweene.com'
+    end
   end
 end


### PR DESCRIPTION
Enable adding website to profile as described in [#353](https://github.com/rubycorns/rorganize.it/issues/353) 

TODO:
- [x] Make a website partial that takes care of turning the website string into a link

- [x] Make the labels clickable for accessibility reasons

- [x] Parse website for `https://` or `http://` and if not present add `http://`

Additionally:
- we adjusted the readme on how to run the specs
- we changed the label tag of the person/edit to be connected to the input in order to put the focus when clicking the label