### PR TITLE
add reset button to filter

### DIFF
--- a/app/assets/stylesheets/custom/_groups_people.scss
+++ b/app/assets/stylesheets/custom/_groups_people.scss
@@ -66,3 +66,8 @@
 .button-class {
   margin-top: 110px;
 }
+
+.reset-button {
+  border: solid 1px #B12200;
+  border-radius: 5px;
+}

--- a/app/views/coaches/index.html.haml
+++ b/app/views/coaches/index.html.haml
@@ -35,4 +35,4 @@
                   %p #{coach.city} #{coach.country}
 
     %aside.sidebar.col-md-4
-      = render 'shared/filter'
+      = render partial: 'shared/filter', locals: { path: coaches_path }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -34,4 +34,4 @@
       %h1.page-header Hey listen!
       %p If you don't see your project group - feel free to add it!
       = link_to "register new group", new_group_path, class: 'btn btn-primary'
-      = render 'shared/filter'
+      = render partial: 'shared/filter', locals: { path: groups_path }

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -14,4 +14,4 @@
                 = render partial: "shared/groups", locals: { object: person }
 
     %aside.sidebar.col-md-4
-      = render 'shared/filter'
+      = render partial: 'shared/filter', locals: { path: people_path }

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -18,3 +18,6 @@
 
   %button{type: 'submit', class: 'btn btn-primary'}
     filter
+
+  - if %w(city country willing_to_travel).any? { |p| params[p] }
+    = link_to "reset", path, class: 'btn reset-button'


### PR DESCRIPTION
This PR adds a reset button to the person & group forms (via the filter partial). Resetting in this case just means redirecting back to either the groups page or the people page. 

I'm a bit confused thou about why I had to do `locals[:path]` [here](https://github.com/rubycorns/rorganize.it/compare/add-reset-button?expand=1#diff-133e1f0b65a4cb828384db8ecd25dc41R22) instead of just `path` since I'm passing it through the locals. I thought that maybe it wasn't working because `path` is a reserved word, so I changed it to a bunch of other things trying to fix it, but it didn't work either. Any thoughts are very welcome!

<img width="409" alt="screen shot 2016-01-12 at 20 42 18" src="https://cloud.githubusercontent.com/assets/4237285/12274832/050f7d7e-b96d-11e5-9d1c-69b1fe963e8d.png">