### PR TITLE
remove railsgirlsapp

### DIFF
--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -17,7 +17,7 @@
 
     %p
       The code is open source. Check it out and contribute on
-      = link_to(fa_icon("github", text: "GitHub"), "//github.com/rubycorns/RailsGirlsApp")
+      = link_to(fa_icon("github", text: "GitHub"), "//github.com/rubycorns/rorganize.it")
     %p
       And we proudly host on Shelly Cloud.
 
@@ -26,5 +26,5 @@
         %img{ src: "//shellycloud.com/assets/badge.png", alt: "Shellycloud badge"}
     %h1.page-header Code of Conduct
     %p
-      Read about our 
+      Read about our
       %a{ href: conduct_path } Code of Conduct

--- a/app/views/person_mailer/new_member_email.html.haml
+++ b/app/views/person_mailer/new_member_email.html.haml
@@ -15,5 +15,5 @@
   %p
     You can find out more about your newest friend by heading over to your
     \#{link_to "project group page", group_url(@group)}.
-  %p Best wishes from the RailsGirlsApp
+  %p Best wishes from Rorganize!
   %p ps - if you like our app, please send cake


### PR DESCRIPTION
closes #404 

Unfortunately I couldn't find the link in the email that still points to railgsirlsapp.shellycloud.com. Everything in the email seems fine unless I'm missing something....