### PR TITLE
Avoid native extensions install errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     fssm (0.2.10)
-    geocoder (1.2.1)
+    geocoder (1.2.14)
     guard (2.6.1)
       formatador (>= 0.2.4)
       listen (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,8 +94,7 @@ GEM
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
-    eventmachine (1.0.3)
-    eventmachine (1.0.3-x86-mingw32)
+    eventmachine (1.0.8)
     execjs (2.0.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -139,7 +138,7 @@ GEM
     jquery-rails (3.1.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.3)
     jwt (1.2.0)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -364,4 +363,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
I'm having troubles with native extensions for json and eventmachine during ```bundle install```. Similar to https://github.com/eventmachine/eventmachine/issues/509 and    https://github.com/flori/json/issues/229#issuecomment-153686657. I'm using archlinux and upgrading to newer gems with ```bundle update json eventmachine``` solves it.

```
        ➜  rorganize.it git:(master) git checkout origin/master
        Note: checking out 'origin/master'.
        
        You are in 'detached HEAD' state. You can look around, make experimental
        changes and commit them, and you can discard any commits you make in this
        state without impacting any branches by performing another checkout.
        
        If you want to create a new branch to retain commits you create, you may
        do so (now or later) by using -b with the checkout command again. Example:
        
          git checkout -b <new-branch-name>
        
        HEAD is now at 8f8221d... Merge pull request #406 from rubycorns/SR-maps-271
        ➜  rorganize.it git:(8f8221d) ruby --version 
        ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-linux]
        ➜  rorganize.it git:(8f8221d) gem env
        RubyGems Environment:
          - RUBYGEMS VERSION: 2.2.2
          - RUBY VERSION: 2.1.5 (2014-11-13 patchlevel 273) [x86_64-linux]
          - INSTALLATION DIRECTORY: /home/robert/.gem/ruby/2.3.0
          - RUBY EXECUTABLE: /home/robert/.rbenv/versions/2.1.5/bin/ruby
          - EXECUTABLE DIRECTORY: /home/robert/.gem/ruby/2.3.0/bin
          - SPEC CACHE DIRECTORY: /home/robert/.gem/specs
          - RUBYGEMS PLATFORMS:
            - ruby
            - x86_64-linux
          - GEM PATHS:
             - /home/robert/.gem/ruby/2.3.0
             - /home/robert/.gem/ruby/2.1.0
             - /home/robert/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0
          - GEM CONFIGURATION:
             - :update_sources => true
             - :verbose => true
             - :backtrace => false
             - :bulk_threshold => 1000
          - REMOTE SOURCES:
             - https://rubygems.org/
          - SHELL PATH:
             - /home/robert/.rbenv/versions/2.1.5/bin
             - /usr/lib/rbenv/libexec
             - /home/robert/.rbenv/shims
             - /home/robert/.gem/ruby/2.3.0/bin
             - /opt/android-sdk/build-tools/20
             - /opt/android-sdk/tools
             - /opt/android-sdk/platform-tools
             - /usr/local/sbin
             - /usr/local/bin
             - /usr/bin
             - /usr/bin/vendor_perl
             - /usr/bin/core_perl
             - /home/robert/.gem/ruby/2.1.0/bin
             - /home/robert/.node_modules/bin
        ➜  rorganize.it git:(8f8221d) which gem
        /home/robert/.rbenv/shims/gem
        ➜  rorganize.it git:(8f8221d) which ruby
        /home/robert/.rbenv/shims/ruby
        ➜  rorganize.it git:(8f8221d) bundle install
        Fetching gem metadata from https://rubygems.org/........
        Fetching version metadata from https://rubygems.org/...
        Fetching dependency metadata from https://rubygems.org/..
        Using rake 10.3.2
        Using i18n 0.6.11
        Installing json 1.8.1 with native extensions
        
        Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
        
            current directory: /home/robert/.gem/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
        /usr/bin/ruby -r ./siteconf20160112-15142-1ywye0o.rb extconf.rb
        creating Makefile
        
        current directory: /home/robert/.gem/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
        make "DESTDIR=" clean
        
        current directory: /home/robert/.gem/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
        make "DESTDIR="
        compiling generator.c
        In file included from /usr/include/stdio.h:27:0,
                         from /usr/include/ruby-2.3.0/ruby/defines.h:26,
                         from /usr/include/ruby-2.3.0/ruby/ruby.h:29,
                         from /usr/include/ruby-2.3.0/ruby.h:33,
                         from ../fbuffer/fbuffer.h:5,
                         from generator.c:1:
        /usr/include/features.h:328:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
         #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
            ^
        In file included from generator.c:1:0:
        ../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
        ../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
             VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                                       ^
        ../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
             VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                            ^
        Makefile:238: recipe for target 'generator.o' failed
        make: *** [generator.o] Error 1
        
        make failed, exit code 2
        
        Gem files will remain installed in /home/robert/.gem/ruby/2.3.0/gems/json-1.8.1 for inspection.
        Results logged to /home/robert/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/json-1.8.1/gem_make.out
        Using minitest 5.4.0
        Using thread_safe 0.3.4
        Using builder 3.2.2
        Using erubis 2.7.0
        Using rack 1.5.2
        Using mime-types 1.25.1
        Using polyglot 0.3.5
        Using arel 5.0.1.20140414130214
        Using addressable 2.3.6
        Using bcrypt 3.1.7
        Using coderay 1.1.0
        Using debug_inspector 0.0.2
        Using sass 3.2.19
        Using mini_portile 0.6.0
        Using timers 1.1.0
        Using chunky_png 1.3.1
        Using coffee-script-source 1.7.0
        Using execjs 2.0.2
        Using thor 0.19.1
        Using fssm 0.2.10
        Using currencies 0.4.2
        Using unicode_utils 1.4.0
        Using daemons 1.1.9
        Using database_cleaner 1.2.0
        Using orm_adapter 0.5.0
        Using diff-lcs 1.2.5
        Using tilt 1.4.1
        Using hpricot 0.8.6
        Using sexp_processor 4.4.4
        Installing eventmachine 1.0.3 with native extensions
        
        Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
        
            current directory: /home/robert/.gem/ruby/2.3.0/gems/eventmachine-1.0.3/ext
        /usr/bin/ruby -r ./siteconf20160112-15142-1883tlj.rb extconf.rb
        checking for rb_trap_immediate in ruby.h,rubysig.h... no
        checking for rb_thread_blocking_region()... no
        checking for inotify_init() in sys/inotify.h... yes
        checking for writev() in sys/uio.h... yes
        checking for rb_wait_for_single_fd()... yes
        checking for rb_enable_interrupt()... no
        checking for rb_time_new()... yes
        checking for sys/event.h... no
        checking for epoll_create() in sys/epoll.h... yes
        creating Makefile
        
        To see why this extension failed to compile, please check the mkmf.log which can be found here:
        
          /home/robert/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/eventmachine-1.0.3/mkmf.log
        
        current directory: /home/robert/.gem/ruby/2.3.0/gems/eventmachine-1.0.3/ext
        make "DESTDIR=" clean
        
        current directory: /home/robert/.gem/ruby/2.3.0/gems/eventmachine-1.0.3/ext
        make "DESTDIR="
        compiling em.cpp
        em.cpp: In member function ‘void EventMachine_t::_RunEpollOnce()’:
        em.cpp:574:37: error: ‘rb_thread_select’ was not declared in this scope
           EmSelect (0, NULL, NULL, NULL, &tv);
                                             ^
        em.cpp: In member function ‘int SelectData_t::_Select()’:
        em.cpp:827:67: error: ‘rb_thread_select’ was not declared in this scope
          return EmSelect (maxsocket+1, &fdreads, &fdwrites, &fderrors, &tv);
                                                                           ^
        em.cpp: In member function ‘void EventMachine_t::_RunSelectOnce()’:
        em.cpp:946:40: error: ‘rb_thread_select’ was not declared in this scope
              EmSelect (0, NULL, NULL, NULL, &tv);
                                                ^
        em.cpp: In member function ‘void EventMachine_t::SignalLoopBreaker()’:
        em.cpp:282:34: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
          write (LoopBreakerWriter, "", 1);
                                          ^
        em.cpp: In member function ‘void EventMachine_t::_ReadLoopBreaker()’:
        em.cpp:991:50: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
          read (LoopBreakerReader, buffer, sizeof(buffer));
                                                          ^
        Makefile:230: recipe for target 'em.o' failed
        make: *** [em.o] Error 1
        
        make failed, exit code 2
        
        Gem files will remain installed in /home/robert/.gem/ruby/2.3.0/gems/eventmachine-1.0.3 for inspection.
        Results logged to /home/robert/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/eventmachine-1.0.3/gem_make.out
        Using multipart-post 2.0.0
        Using ffi 1.9.3
        Using formatador 0.2.4
        Using geocoder 1.2.1
        Using rb-fsevent 0.9.4
        Using lumberjack 1.0.5
        Using method_source 0.8.2
        Using slop 3.5.0
        Using rspec-support 3.0.3
        Using hashie 3.3.2
        Using hike 1.2.3
        Using multi_json 1.10.1
        Using jwt 1.2.0
        Using redcarpet 3.2.3
        Using subexec 0.2.3
        Using modernizr-rails 2.6.2.3
        Using multi_xml 0.5.5
        Using pg 0.17.1
        Using bundler 1.11.2
        Using spring 1.1.3
        Using sqlite3 1.3.9
        Using timecop 0.7.3
        Using will_paginate 3.0.5
        An error occurred while installing json (1.8.1), and Bundler cannot continue.
        Make sure that `gem install json -v '1.8.1'` succeeds before bundling.
        ➜  rorganize.it git:(8f8221d) git checkout avoid_native_extensions_install_errors 
        Previous HEAD position was 8f8221d... Merge pull request #406 from rubycorns/SR-maps-271
        Switched to branch 'avoid_native_extensions_install_errors'
        Your branch is up-to-date with 'roschaefer/avoid_native_extensions_install_errors'.
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) ruby --version 
        ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-linux]
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) gem env
        RubyGems Environment:
          - RUBYGEMS VERSION: 2.2.2
          - RUBY VERSION: 2.1.5 (2014-11-13 patchlevel 273) [x86_64-linux]
          - INSTALLATION DIRECTORY: /home/robert/.gem/ruby/2.3.0
          - RUBY EXECUTABLE: /home/robert/.rbenv/versions/2.1.5/bin/ruby
          - EXECUTABLE DIRECTORY: /home/robert/.gem/ruby/2.3.0/bin
          - SPEC CACHE DIRECTORY: /home/robert/.gem/specs
          - RUBYGEMS PLATFORMS:
            - ruby
            - x86_64-linux
          - GEM PATHS:
             - /home/robert/.gem/ruby/2.3.0
             - /home/robert/.gem/ruby/2.1.0
             - /home/robert/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0
          - GEM CONFIGURATION:
             - :update_sources => true
             - :verbose => true
             - :backtrace => false
             - :bulk_threshold => 1000
          - REMOTE SOURCES:
             - https://rubygems.org/
          - SHELL PATH:
             - /home/robert/.rbenv/versions/2.1.5/bin
             - /usr/lib/rbenv/libexec
             - /home/robert/.rbenv/shims
             - /home/robert/.gem/ruby/2.3.0/bin
             - /opt/android-sdk/build-tools/20
             - /opt/android-sdk/tools
             - /opt/android-sdk/platform-tools
             - /usr/local/sbin
             - /usr/local/bin
             - /usr/bin
             - /usr/bin/vendor_perl
             - /usr/bin/core_perl
             - /home/robert/.gem/ruby/2.1.0/bin
             - /home/robert/.node_modules/bin
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) which ruby
        /home/robert/.rbenv/shims/ruby
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) which gem
        /home/robert/.rbenv/shims/gem
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) bundle install
        Using rake 10.3.2
        Using i18n 0.6.11
        Using json 1.8.3
        Using minitest 5.4.0
        Using thread_safe 0.3.4
        Using builder 3.2.2
        Using erubis 2.7.0
        Using rack 1.5.2
        Using mime-types 1.25.1
        Using polyglot 0.3.5
        Using arel 5.0.1.20140414130214
        Using addressable 2.3.6
        Using bcrypt 3.1.7
        Using coderay 1.1.0
        Using debug_inspector 0.0.2
        Using sass 3.2.19
        Using mini_portile 0.6.0
        Using timers 1.1.0
        Using chunky_png 1.3.1
        Using coffee-script-source 1.7.0
        Using execjs 2.0.2
        Using thor 0.19.1
        Using fssm 0.2.10
        Using currencies 0.4.2
        Using unicode_utils 1.4.0
        Using daemons 1.1.9
        Using database_cleaner 1.2.0
        Using orm_adapter 0.5.0
        Using diff-lcs 1.2.5
        Using tilt 1.4.1
        Using hpricot 0.8.6
        Using sexp_processor 4.4.4
        Using eventmachine 1.0.8
        Using multipart-post 2.0.0
        Using ffi 1.9.3
        Using formatador 0.2.4
        Using geocoder 1.2.14
        Using rb-fsevent 0.9.4
        Using lumberjack 1.0.5
        Using method_source 0.8.2
        Using slop 3.5.0
        Using rspec-support 3.0.3
        Using hashie 3.3.2
        Using hike 1.2.3
        Using multi_json 1.10.1
        Using jwt 1.2.0
        Using redcarpet 3.2.3
        Using subexec 0.2.3
        Using modernizr-rails 2.6.2.3
        Using multi_xml 0.5.5
        Using pg 0.17.1
        Using bundler 1.11.2
        Using spring 1.1.3
        Using sqlite3 1.3.9
        Using timecop 0.7.3
        Using will_paginate 3.0.5
        Using emoji 1.0.1
        Using rdoc 4.1.1
        Using tzinfo 1.2.2
        Using rack-test 0.6.2
        Using warden 1.2.3
        Using treetop 1.4.15
        Using launchy 2.4.2
        Using better_errors 1.1.0
        Using binding_of_caller 0.7.2
        Using bootstrap-sass 3.1.1.1
        Using nokogiri 1.6.3.1
        Using celluloid 0.15.2
        Using coffee-script 2.2.0
        Using uglifier 2.5.0
        Using compass 0.12.6
        Using countries 0.9.3
        Using sort_alphabetical 1.0.1
        Using haml 4.0.5
        Using ruby_parser 3.1.3
        Using thin 1.6.2
        Using faraday 0.9.1
        Using rb-inotify 0.9.4
        Using pry 0.9.12.6
        Using rspec-core 3.0.3
        Using rspec-expectations 3.0.3
        Using rspec-mocks 3.0.3
        Using omniauth 1.2.2
        Using sprockets 2.11.0
        Using mini_magick 3.7.0
        Using spring-commands-rspec 1.0.2
        Using sdoc 0.4.0
        Using activesupport 4.1.4
        Using mail 2.5.4
        Using xpath 2.0.0
        Using country_select 2.1.1 from git://github.com/stefanpenner/country_select.git (at master@68ae9f9)
        Using html2haml 1.0.1
        Using shelly-dependencies 0.2.4
        Using oauth2 1.0.0
        Using listen 2.7.5
        Using pry-rails 0.3.2
        Using rspec-its 1.0.1
        Using rspec 3.0.0
        Using actionview 4.1.4
        Using activemodel 4.1.4
        Using factory_girl 4.4.0
        Using jbuilder 1.5.3
        Using shoulda-matchers 2.6.1
        Using capybara 2.3.0
        Using erb2haml 0.1.5
        Using omniauth-oauth2 1.2.0
        Using guard 2.6.1
        Using actionpack 4.1.4
        Using activerecord 4.1.4
        Using carrierwave 0.10.0
        Using omniauth-github 1.1.2
        Using guard-rspec 4.2.9
        Using actionmailer 4.1.4
        Using railties 4.1.4
        Using sprockets-rails 2.1.3
        Using annotate 2.6.3
        Using friendly_id 5.1.0
        Using coffee-rails 4.0.1
        Using devise 3.2.4
        Using factory_girl_rails 4.4.1
        Using font-awesome-rails 4.1.0.0
        Using jquery-rails 3.1.0
        Using md_emoji 1.0.2
        Using rspec-rails 3.0.2
        Using rails 4.1.4
        Using sass-rails 4.0.3
        Using turbolinks 2.2.2
        Using rails_autolink 1.1.5
        Bundle complete! 45 Gemfile dependencies, 128 gems now installed.
        Use `bundle show [gemname]` to see where a bundled gem is installed.
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) cat /etc/*-release
        NAME="Arch Linux"
        ID=arch
        PRETTY_NAME="Arch Linux"
        ANSI_COLOR="0;36"
        HOME_URL="https://www.archlinux.org/"
        SUPPORT_URL="https://bbs.archlinux.org/"
        BUG_REPORT_URL="https://bugs.archlinux.org/"
        
        ➜  rorganize.it git:(avoid_native_extensions_install_errors) uname -r
        4.3.3-2-ARCH

```