### PR TITLE
update geocoder (deprecation warnings)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     fssm (0.2.10)
-    geocoder (1.2.1)
+    geocoder (1.2.14)
     guard (2.6.1)
       formatador (>= 0.2.4)
       listen (~> 2.7)
@@ -363,4 +363,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
I noticed that you [updated ```json``` and ```eventmachine```](https://github.com/rubycorns/rorganize.it/commit/bd536b15457994626bcf27b2c9423ed025f7b9be). I was wrong to believe that it is a problem for linux users, it seems to be a problem just for me. But if you want to make my life easier, well.. thanks :smiley_cat: 

Nevertheless, you probably want to update ```geocoder```. The current master branch spits out some [deprecation warnings](https://travis-ci.org/rubycorns/rorganize.it/jobs/102158129) if you run ```bundle exec rspec```.