### PR TITLE
Isolate tests from network connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,8 @@ group :development, :test do
   gem 'minitest'
   gem 'rspec-its', '~> 1.0.1'
   gem 'timecop'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       sass (~> 3.2.19)
     countries (0.9.3)
       currencies (~> 0.4.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     currencies (0.4.2)
     daemons (1.1.9)
     database_cleaner (1.2.0)
@@ -123,6 +125,7 @@ GEM
       rspec (>= 2.14, < 4.0)
     haml (4.0.5)
       tilt
+    hashdiff (0.2.3)
     hashie (3.3.2)
     hike (1.2.3)
     hpricot (0.8.6)
@@ -251,6 +254,7 @@ GEM
     rspec-support (3.0.3)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -304,8 +308,13 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicode_utils (1.4.0)
+    vcr (3.0.1)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     will_paginate (3.0.5)
     win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
@@ -360,6 +369,8 @@ DEPENDENCIES
   timecop
   turbolinks
   uglifier (>= 1.3.0)
+  vcr
+  webmock
   will_paginate
 
 BUNDLED WITH

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe GroupsController do
+describe GroupsController, :vcr => {:cassette_name => "create_group" } do
 
   describe 'create' do
     let(:person) { create(:person) }

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MembershipsController do
+describe MembershipsController, :vcr => {:cassette_name => "create_group" } do
   let!(:person) { create(:person) }
   let(:group) { create(:group) }
 

--- a/spec/features/admin_remove_person_spec.rb
+++ b/spec/features/admin_remove_person_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Remove a person from a group' do
+feature 'Remove a person from a group', :vcr => {:cassette_name => "create_group" } do
 
   let(:person) { create(:person) }
   let(:group) { create(:group) }

--- a/spec/features/group_create_spec.rb
+++ b/spec/features/group_create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'create a group' do
+feature 'create a group', :vcr => {:cassette_name => "create_group" } do
 
   before { visit new_person_session_path }
   before { sign_in person }

--- a/spec/features/group_delete_spec.rb
+++ b/spec/features/group_delete_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'admins can delete groups' do
+feature 'admins can delete groups', :vcr => {:cassette_name => "create_group" } do
 
   before { visit new_person_session_path }
 

--- a/spec/features/group_edit_spec.rb
+++ b/spec/features/group_edit_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'edit a group' do
+feature 'edit a group', :vcr => {:cassette_name => "create_group" } do
 
   before { visit new_person_session_path }
   before { sign_in person }

--- a/spec/features/group_topics_spec.rb
+++ b/spec/features/group_topics_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Manage topics of a group' do
+feature 'Manage topics of a group', :vcr => {:cassette_name => "create_group" } do
 
   scenario 'Add topic' do
     visit_group_page

--- a/spec/features/not_logged_in_user_spec.rb
+++ b/spec/features/not_logged_in_user_spec.rb
@@ -28,7 +28,7 @@ describe 'User is not logged in', :type => :feature do
     end
   end
 
-  context 'a group detail page' do
+  context 'a group detail page', :vcr => {:cassette_name => "create_group" } do
 
     # added activities otherwise the markdown field receives a value of 'nil'
     # and the test fails

--- a/spec/features/slug_spec.rb
+++ b/spec/features/slug_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'slugs' do
+feature 'slugs', :vcr => {:cassette_name => "create_group" } do
 
   before { visit new_person_session_path }
 

--- a/spec/fixtures/vcr_cassettes/create_group.yml
+++ b/spec/fixtures/vcr_cassettes/create_group.yml
@@ -1,0 +1,288 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=%20%20%20Berlin%20DE&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 18 Jan 2016 01:04:54 GMT
+      Expires:
+      - Tue, 19 Jan 2016 01:04:54 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '409'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Berlin",
+                       "short_name" : "Berlin",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Berlin",
+                       "short_name" : "Berlin",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Germany",
+                       "short_name" : "DE",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Berlin, Germany",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 52.6754542,
+                          "lng" : 13.7611176
+                       },
+                       "southwest" : {
+                          "lat" : 52.33962959999999,
+                          "lng" : 13.0891553
+                       }
+                    },
+                    "location" : {
+                       "lat" : 52.52000659999999,
+                       "lng" : 13.404954
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 52.6754542,
+                          "lng" : 13.7611176
+                       },
+                       "southwest" : {
+                          "lat" : 52.33962959999999,
+                          "lng" : 13.0891553
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJAVkDPzdOqEcRcDteW0YgIQQ",
+                 "types" : [ "locality", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 18 Jan 2016 01:04:54 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=%20%20%20Hamburg%20DE&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 18 Jan 2016 01:05:05 GMT
+      Expires:
+      - Tue, 19 Jan 2016 01:05:05 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '437'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Hamburg",
+                       "short_name" : "Hamburg",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Hamburg",
+                       "short_name" : "HH",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Germany",
+                       "short_name" : "DE",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Hamburg, Germany",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 53.7394338,
+                          "lng" : 10.32528
+                       },
+                       "southwest" : {
+                          "lat" : 53.3962857,
+                          "lng" : 9.7301316
+                       }
+                    },
+                    "location" : {
+                       "lat" : 53.5510846,
+                       "lng" : 9.993681799999999
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 53.717145,
+                          "lng" : 10.123492
+                       },
+                       "southwest" : {
+                          "lat" : 53.399999,
+                          "lng" : 9.732151000000002
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJuRMYfoNhsUcRoDrWe_I9JgQ",
+                 "types" : [ "locality", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 18 Jan 2016 01:05:05 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=%20%20%20Berlin%20DE&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 18 Jan 2016 01:05:55 GMT
+      Expires:
+      - Tue, 19 Jan 2016 01:05:55 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '409'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Berlin",
+                       "short_name" : "Berlin",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Berlin",
+                       "short_name" : "Berlin",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "Germany",
+                       "short_name" : "DE",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Berlin, Germany",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 52.6754542,
+                          "lng" : 13.7611176
+                       },
+                       "southwest" : {
+                          "lat" : 52.33962959999999,
+                          "lng" : 13.0891553
+                       }
+                    },
+                    "location" : {
+                       "lat" : 52.52000659999999,
+                       "lng" : 13.404954
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 52.6754542,
+                          "lng" : 13.7611176
+                       },
+                       "southwest" : {
+                          "lat" : 52.33962959999999,
+                          "lng" : 13.0891553
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJAVkDPzdOqEcRcDteW0YgIQQ",
+                 "types" : [ "locality", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 18 Jan 2016 01:05:55 GMT
+recorded_with: VCR 3.0.1

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -27,7 +27,7 @@
 
 require 'spec_helper'
 
-describe Group do
+describe Group, :vcr => {:cassette_name => "create_group" } do
 
   let!(:group) { create(:group) }
   let!(:person) { create(:person) }

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -12,7 +12,7 @@
 
 require 'spec_helper'
 
-describe Membership do
+describe Membership, :vcr => {:cassette_name => "create_group" } do
   let(:person) { create(:person) }
   let!(:group) { create(:group) }
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -26,7 +26,7 @@
 
 require 'spec_helper'
 
-describe Person do
+describe Person, :vcr => {:cassette_name => "create_group" } do
 
   it { is_expected.to have_many(:groups) }
   it { is_expected.to have_many(:memberships) }

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,8 @@
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  c.hook_into :webmock
+  c.default_cassette_options = { :record => :new_episodes}
+  c.configure_rspec_metadata!
+end


### PR DESCRIPTION
fixes #361 
Whenever you ```create(:group)``` in the tests you trigger the geocode api in an [after_validation](https://github.com/rubycorns/rorganize.it/blob/master/app/models/group.rb#L50) hook. I decided to use an explicit cassette in every rspec context that uses this group factory. We could also do something similar to [*this*](http://stackoverflow.com/q/16533980). But it adds extra complexity and you get confused if you write another rspec test that triggers a different http request. In my opinion, the ideal solution would be to follow [this suggestion](http://stackoverflow.com/a/7861809).