### PR TITLE
display country name everywhere not iso_code

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 module ApplicationHelper
 
-
   def flash_class(level)
     case level
       when :notice then "info"
@@ -11,7 +10,6 @@ module ApplicationHelper
   end
 
   def markdown(text)
-
     emoji = Redcarpet::Markdown.new(
       MdEmoji::Render.new(filter_html: true),
       no_intra_emphasis: true,
@@ -21,6 +19,10 @@ module ApplicationHelper
     )
 
     raw emoji.render(text)
+  end
+
+  def country_names_for_select(countries)
+    countries.map { |c| [ISO3166::Country[c].name, c] }
   end
 
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -17,8 +17,8 @@ module GroupsHelper
     end
   end
 
-  def group_location(group) 
-    [group.street, group.zip, group.city, group.country].select {|x| x.present? }.join(', ')
+  def group_location(group)
+    [group.street, group.zip, group.city, group.country_name].select {|x| x.present? }.join(', ')
   end
 
 end

--- a/app/models/concerns/location_filter.rb
+++ b/app/models/concerns/location_filter.rb
@@ -9,4 +9,8 @@ module LocationFilter
     scope :by_country, -> (country) { where(country: country) }
   end
 
+  def country_name
+    ISO3166::Country[country].name if country.present?
+  end
+
 end

--- a/app/views/coaches/index.html.haml
+++ b/app/views/coaches/index.html.haml
@@ -32,7 +32,7 @@
                 %h3
                   = profile_link(coach)
                 - if logged_in?(current_person) && coach_location?(coach)
-                  %p #{coach.city} #{coach.country}
+                  %p #{coach.city} #{coach.country_name}
 
     %aside.sidebar.col-md-4
       = render 'shared/filter'

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -40,7 +40,7 @@
       - if coach_location?(@person)
         %p
           %strong Based in:
-          #{@person.city} #{@person.country}
+          #{@person.city} #{@person.country_name}
     .col-md-4
       %h4 Project Groups:
       - if @person.has_group?

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -8,7 +8,7 @@
   .row.filter-option
     %label.col-md-3.control-label country
     .col-md-8
-      = select_tag 'country', options_for_select(@countries), include_blank: true, class: 'form-control'
+      = select_tag 'country', options_for_select(country_names_for_select(@countries)), include_blank: true, class: 'form-control'
 
   - if current_page?(coaches_path)
     .row.filter-option

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ group_list = [
     activities: 'We build a wishlist app to organize christmas for large families. Users can enter their own wishlist and add wishes. Other users can comment on these wishes, mark them as done etc, but the list owner can’t see that of course.',
     email: 'group1@example.org',
     city: 'Berlin',
-    country: 'Germany',
+    country: 'DE',
     street: 'Blücherstraße 22',
     zip: '10961'
   },
@@ -27,7 +27,7 @@ group_list = [
     activities: 'We basically meet and have coding sessions where we show of stuff as needed. Sometimes Tobi gives a presentation from his HU course or something. Basically everything including homeworks is pretty ad-hoc.',
     email: 'group2@example.org',
     city: 'Berlin',
-    country: 'Germany',
+    country: 'DE',
     street: 'Sanderstr. 28 ',
     zip: '12047'
   },
@@ -39,7 +39,7 @@ group_list = [
     activities: 'Nothing specific, we do exercises around basic web apps with Sinatra.',
     email: 'group3@example.org',
     city: 'Berlin',
-    country: 'Germany',
+    country: 'DE',
     street: 'Adalbertstraße 8',
     zip: '10999'
   },
@@ -52,7 +52,7 @@ group_list = [
     email: 'group4@example.org',
     full: true,
     city: 'Berlin',
-    country: 'Germany',
+    country: 'DE',
     street: 'Prinzessinnenstr. 20',
     zip: '10969'
   }
@@ -69,6 +69,8 @@ user_list = [
     email: 'student@example.org',
     password: 'testtest',
     twitter: '@studenttwitter',
+    country: 'CA',
+    city: 'Toronto'
   },
   {
     first_name: 'Coach',
@@ -77,6 +79,8 @@ user_list = [
     password: 'testtest',
     twitter: '@coachtwitter',
     admin: true,
+    country: 'US',
+    city: 'New York'
   }
 ]
 user_list.each do |user|

--- a/spec/features/group_edit_spec.rb
+++ b/spec/features/group_edit_spec.rb
@@ -27,7 +27,7 @@ feature 'edit a group' do
     select 'France'
     click_button 'Update Group'
 
-    expect(page).to have_content('Not Berlin, FR')
+    expect(page).to have_content('Not Berlin, France')
   end
 
   scenario 'make current group inactive' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,3 +10,10 @@ describe 'markdown helper', :type => :helper do
     expect(helper.markdown(':coffee:')).to match(/assets\/emojis\/coffee.png/)
   end
 end
+
+describe '#country_names_for_select' do
+  it 'convers the country codes to country name' do
+    countries = ['DE', 'CA', 'US']
+    expect(helper.country_names_for_select(countries)).to eql [["Germany", "DE"], ["Canada", "CA"], ["United States", "US"]]
+  end
+end

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -103,4 +103,17 @@ describe GroupsHelper do
       end
     end
   end
+
+  describe '#group_location' do
+    let(:group) { build_stubbed :group, city: 'Berlin', country: 'DE', street: 'Willy-Brandt-Straße 1', zip: '10557' }
+    let(:group_empty) { build_stubbed :group, city: nil, country: nil }
+
+    it 'returns a string with all relevant location info together' do
+      expect(helper.group_location(group)).to eql 'Willy-Brandt-Straße 1, 10557, Berlin, Germany'
+    end
+
+    it 'does not complain if none of that info is present' do
+      expect(helper.group_location(group_empty)).to eql ''
+    end
+  end
 end

--- a/spec/models/concerns/location_filter_spec.rb
+++ b/spec/models/concerns/location_filter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe LocationFilter do
+
+  describe '#country_name' do
+    let(:group) { build_stubbed :group, country: 'DE' }
+    let(:group_empty) { build_stubbed :group, country: nil }
+
+    it 'is present' do
+      expect(group.country_name).to eql 'Germany'
+    end
+
+    it 'is not present' do
+      expect(group_empty.country_name).to eql nil
+    end
+  end
+end


### PR DESCRIPTION
closes #419

I didn't only change them in the filter dropdown but also in various other places like the person#show and the people indexes etc.... so in THEORY, there shouldn't be any iso codes for countries anymore, it should all just be full country names. 