### PR TITLE
Catch http requests only for test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,9 @@ group :development, :test do
   gem 'minitest'
   gem 'rspec-its', '~> 1.0.1'
   gem 'timecop'
+end
+
+group :test do
   gem 'vcr'
   gem 'webmock'
 end


### PR DESCRIPTION
In development environment ```bin/rake db:setup``` fails because it's surpressing http requests.