### PR TITLE
remove signup buttons for inactive groups

### DIFF
--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -5,14 +5,6 @@ module GroupsHelper
     !person.member_of?(group)
   end
 
-  def group_open?(group)
-    !group.full?
-  end
-
-  def group_active?(group)
-    !group.inactive
-  end
-
   def show_member_buttons?(person, group)
     if !person_signed_in?
       false

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -5,8 +5,12 @@ module GroupsHelper
     !person.member_of?(group)
   end
 
-  def even_a_button?(group)
+  def group_open?(group)
     !group.full?
+  end
+
+  def group_active?(group)
+    !group.inactive
   end
 
   def show_member_buttons?(person, group)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -66,6 +66,10 @@ class Group < ActiveRecord::Base
     !full
   end
 
+  def active?
+    !inactive
+  end
+
   def location
     [address, street, zip, city, country].join(' ')
   end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -24,7 +24,7 @@
                   %li
                     = render 'leave'
 
-            - if even_a_button?(@group) && show_join_group_button?(current_person, @group)
+            - if group_open?(@group) && group_active?(@group) && show_join_group_button?(current_person, @group)
               = render 'join'
 
             - if @group.inactive?

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -24,7 +24,7 @@
                   %li
                     = render 'leave'
 
-            - if group_open?(@group) && group_active?(@group) && show_join_group_button?(current_person, @group)
+            - if @group.not_full? && @group.active? && show_join_group_button?(current_person, @group)
               = render 'join'
 
             - if @group.inactive?

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -45,42 +45,6 @@ describe GroupsHelper do
     end
   end
 
-  describe '#group_open?' do
-    context 'group is not full' do
-      let(:group) { double(full?: false) }
-
-      it 'shows the button' do
-        expect(helper.group_open?(group)).to be true
-      end
-    end
-
-    context 'group is full' do
-      let(:group) { double(full?: true) }
-
-      it 'does not show the button' do
-        expect(helper.group_open?(group)).to be false
-      end
-    end
-  end
-
-  describe '#group_active?' do
-    context 'group is not active' do
-      let(:group) { double(inactive: true) }
-
-      it 'does not show the button' do
-        expect(helper.group_active?(group)).to be false
-      end
-    end
-
-    context 'group is active' do
-      let(:group) { double(inactive: false) }
-
-      it 'shoes the button' do
-        expect(helper.group_active?(group)).to be true
-      end
-    end
-  end
-
   describe 'show_member_buttons?' do
 
     subject do

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -45,12 +45,12 @@ describe GroupsHelper do
     end
   end
 
-  describe '#even_a_button?' do
+  describe '#group_open?' do
     context 'group is not full' do
       let(:group) { double(full?: false) }
 
       it 'shows the button' do
-        expect(helper.even_a_button?(group)).to be true
+        expect(helper.group_open?(group)).to be true
       end
     end
 
@@ -58,7 +58,25 @@ describe GroupsHelper do
       let(:group) { double(full?: true) }
 
       it 'does not show the button' do
-        expect(helper.even_a_button?(group)).to be false
+        expect(helper.group_open?(group)).to be false
+      end
+    end
+  end
+
+  describe '#group_active?' do
+    context 'group is not active' do
+      let(:group) { double(inactive: true) }
+
+      it 'does not show the button' do
+        expect(helper.group_active?(group)).to be false
+      end
+    end
+
+    context 'group is active' do
+      let(:group) { double(inactive: false) }
+
+      it 'shoes the button' do
+        expect(helper.group_active?(group)).to be true
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -74,6 +74,13 @@ describe Group, :vcr => {:cassette_name => "create_group" } do
     end
   end
 
+  describe '#active?' do
+    it 'is active' do
+      group.inactive = false
+      expect(group.active?).to be true
+    end
+  end
+
   context 'filtering by city or country' do
     let!(:group) { create :group }
     let!(:second_group) { create :second_group }


### PR DESCRIPTION
closes https://github.com/rubycorns/rorganize.it/issues/434

It is also the end of an era.... bye bye `even_a_button?`. It's been a blast. But unfortunately, you make no sense anymore. 

What are you even doing? I no longer know. 

![sad](https://media.giphy.com/media/U2sRHJWyehtPq/giphy.gif)