### PR TITLE
inactive badge on index

### DIFF
--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -23,6 +23,10 @@
                 .col-md-2
                   %span.label.label-danger
                     FULL
+              - if group.inactive?
+                .col-md-2
+                  %span.label.label-warning
+                    INACTIVE
               .col-md-2
                 %p
                   - if group.editable_by?(current_person)


### PR DESCRIPTION
closes https://github.com/rubycorns/rorganize.it/issues/435

the badge is yellow.... I made a choice. `¯\_(ツ)_/¯`
<img width="791" alt="screen shot 2016-03-15 at 21 17 04" src="https://cloud.githubusercontent.com/assets/4237285/13792709/822ab64a-eaf3-11e5-9e64-5c31ccae5ae3.png">
