### PR TITLE
Fix bug filtering groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,8 +7,9 @@ class GroupsController < ApplicationController
   before_action :ensure_member_powers, except: [:index, :show, :new, :create, :destroy]
 
   def index
-    @groups_inactive, @groups = Group.all.order(:name).partition { |g| g.inactive? }
-    
+    @groups = Group.where(inactive: false).order(:name)
+    @groups_inactive = Group.where(inactive: true).order(:name)
+
     @groups = @groups.by_country(params[:country]) if params[:country].present?
     @groups = @groups.by_city(params[:city]) if params[:city].present?
 


### PR DESCRIPTION
This fixes #465 (makes the reset button show up as well)

The error message when I tried recreating the bug locally was "undefined method `by_city' for #<Array:...>", so I assume it was caused by the following:
"partition" returns an array, and by_country/by_city are scopes which can only be called on ActiveRecord::Relation objects.
Please correct me if I am wrong :)