### PR TITLE
Autostarts thin server using deamontools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ someone of the Rubycorns to give you access.
 
 Then in your local repository, add a git remote for production:
 
-    git remote add production ror@rorganize.it:html/rorganize.it
+    git remote add production ror@rorganize.it:rorganize.it
 
 That should be it. The scripts that are run after a push are in the [deploy](https://github.com/rubycorns/rorganize.it/tree/master/deploy)
 directory. See also https://github.com/mislav/git-deploy for more info.
 
-In case this doesn't work though, ssh into server, cd into application folder (in html folder), and try:
+In case this doesn't work though, ssh into server and try to restart deamontools:
 
-    bundle exec thin -a 127.0.0.1 -p 34567 -d start
+    svc -t /service/autostart

--- a/deploy/autostart
+++ b/deploy/autostart
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# start thin as a process in the foreground
-# (when thin is down, deamontools will execute)
-bundle exec thin -a 127.0.0.1 -p 34567 start
-echo "autostarting thin app server"

--- a/deploy/restart
+++ b/deploy/restart
@@ -1,3 +1,3 @@
 #!/bin/sh
-bundle exec thin -a 127.0.0.1 -p 34567 restart
-echo "restarting thin app server"
+echo "killing thin so deamontools can restart server"
+pkill -f thin


### PR DESCRIPTION
- Removes autostart file (now on server only)
- Changes restart file from restarting thin to killing thin
(so deamontools can restart server)
- Updates readme
- Hopefully closes #480