### PR TITLE
Add action for Change Password link 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,9 @@ class ApplicationController < ActionController::Base
     editable_fields = [
       :first_name,
       :last_name,
+      :password,
+      :password_confirmation,
+      :current_password,
     ]
 
     devise_parameter_sanitizer.for(:sign_up) do |person|

--- a/app/views/people/show.html+redesign.haml
+++ b/app/views/people/show.html+redesign.haml
@@ -30,7 +30,7 @@
       .action-buttons
         = link_to "Edit profile", edit_person_path(@person), class: 'btn btn-teal'
         // TODO: set correct path
-        = link_to "Change password", @person, class: 'btn btn-teal'
+        = link_to "Change password", edit_person_registration_path, class: 'btn btn-teal'
         - if logged_in?(@person)
           = link_to "Delete account", person_registration_path(@person), method: :delete, data: { confirm: "Are you sure you want to delete your account?" }, class: 'btn btn-pink'
         - if @person.provider.present?

--- a/spec/features/edit_person_spec.rb
+++ b/spec/features/edit_person_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 feature 'edit a person' do
 
-  before { visit new_person_session_path }
-  before { sign_in person }
+  before do
+    visit new_person_session_path
+    sign_in person
+  end
 
   let(:person) { create(:person) }
 

--- a/spec/features/group_create_spec.rb
+++ b/spec/features/group_create_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 feature 'create a group', :vcr => {:cassette_name => "create_group" } do
 
-  before { visit new_person_session_path }
-  before { sign_in person }
+  before do
+    visit new_person_session_path
+    sign_in person
+  end
 
   let(:person) { create(:person) }
 

--- a/spec/features/group_edit_spec.rb
+++ b/spec/features/group_edit_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 feature 'edit a group', :vcr => {:cassette_name => "create_group" } do
-  before { visit new_person_session_path }
-  before { sign_in person }
+  before do
+    visit new_person_session_path
+    sign_in person
+  end
 
   context 'as a member of a group' do
     let(:person) { create(:person) }

--- a/spec/features/update_password_spec.rb
+++ b/spec/features/update_password_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+feature 'update password' do
+
+  before { visit new_person_session_path }
+  before { sign_in person }
+
+  let(:person) { create(:person, password: 'password') }
+
+  scenario 'update password' do
+    visit person_path(person, redesign: true)
+    click_on 'Change password'
+    fill_in 'Current password', with: 'password'
+    fill_in 'Password', with: 'test1234'
+    fill_in 'Password confirmation', with: 'test1234'
+    click_on 'Update'
+    expect(page).to have_content 'You updated your account successfully'
+  end
+end

--- a/spec/features/update_password_spec.rb
+++ b/spec/features/update_password_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 feature 'update password' do
 
-  before { visit new_person_session_path }
-  before { sign_in person }
+  before do
+    visit new_person_session_path
+    sign_in person
+  end
 
   let(:person) { create(:person, password: 'password') }
 
@@ -14,6 +16,19 @@ feature 'update password' do
     fill_in 'Password', with: 'test1234'
     fill_in 'Password confirmation', with: 'test1234'
     click_on 'Update'
+
     expect(page).to have_content 'You updated your account successfully'
+    click_on 'logout'
+
+    visit person_session_path
+    fill_in 'Email', with: person.email
+    fill_in 'Password', with: 'password'
+    click_button 'Sign in'
+    expect(page).to have_content 'Invalid email or password'
+
+    fill_in 'Email', with: person.email
+    fill_in 'Password', with: 'test1234'
+    click_button 'Sign in'
+    expect(page).to have_content 'Signed in successfully'
   end
 end


### PR DESCRIPTION
[Add "change password" option #483](https://github.com/rubycorns/rorganize.it/issues/483)

This PR implements correct path for `Change password` button and makes change password works.