### PR TITLE
Add private profiles, closing #284

### DIFF
--- a/app/controllers/coaches_controller.rb
+++ b/app/controllers/coaches_controller.rb
@@ -1,6 +1,7 @@
 class CoachesController < ApplicationController
   def index
     @coaches = Person.workshop_coach.order_by_name
+    @coaches = @coaches.public_profile unless signed_in?
     @coaches = @coaches.by_country(params[:country]) if params[:country].present?
     @coaches = @coaches.by_city(params[:city]) if params[:city].present?
     @coaches = @coaches.willing_to_travel if params[:willing_to_travel] == '1'

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -54,6 +54,11 @@ class GroupsController < ApplicationController
 
     @topic = Topic.new
     @topic.group = @group
+
+    @students = @group.students.public_profile
+    @students = @group.students if signed_in?
+    @coaches = @group.coaches.public_profile
+    @coaches = @group.coaches if signed_in?
   end
 
   def destroy

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,9 @@ class PagesController < ApplicationController
   def index
     @groups = Group.all
     @people = Person.all
-    @students, @coaches = Membership.all.partition { |membership| membership.name == 'Student' }
+    students, coaches = Membership.all.partition { |membership| membership.name == 'Student' }
+    @students_count = students.count
+    @coaches_count = coaches.count
   end
 
   def about

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -4,6 +4,7 @@ class PeopleController < ApplicationController
 
   def index
     @people = Person.order(:first_name).order(:last_name)
+    @people = @people.public_profile unless signed_in?
     @people = @people.by_country(params[:country]) if params[:country].present?
     @people = @people.by_city(params[:city]) if params[:city].present?
 
@@ -34,6 +35,6 @@ class PeopleController < ApplicationController
 
   def person_params
     params.require(:person).permit(:first_name, :last_name, :email,
-    :picture, :twitter, :website, :working_on, :workshop_coach, :city, :country, :willing_to_travel)
+    :picture, :twitter, :website, :working_on, :workshop_coach, :city, :country, :willing_to_travel, :non_public)
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,6 +48,7 @@ class Person < ActiveRecord::Base
   scope :willing_to_travel, -> { where(willing_to_travel: true) }
   scope :order_by_name, -> { order("lower(first_name) ASC, lower(last_name) ASC") }
   scope :workshop_coach, -> { where(workshop_coach: true)}
+  scope :public_profile, -> { where(non_public: false) }
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |person|

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -95,18 +95,24 @@
 
       %h4 Students
       %p
-        This group currently has #{pluralize @group.students.length, "student"}.
+      - if signed_in?
+        This group currently has #{pluralize @students.length, "student"}.
+      - else
+        This group may have more students than currently shown. Log in to see all of them.
       %ul.list--people
-        - @group.students.each do |student|
+        - @students.each do |student|
           %li
             = link_to student.first_name, person_path(student)
             - if admin?
               = render partial: 'remove_from_group', locals: { object: student, group: @group }
       %h4 Coaches
       %p
-        This group currently has #{pluralize @group.coaches.length, "coach"}.
+      - if signed_in?
+        This group currently has #{pluralize @coaches.length, "coach"}.
+      - else
+        This group may have more coaches than currently shown. Log in to see all of them.
       %ul.list--people
-        - @group.coaches.each do |coach|
+        - @coaches.each do |coach|
           %li
             = link_to coach.first_name, person_path(coach)
             - if admin?

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -20,9 +20,9 @@
     %h2 Discover and meet
     .col-md-6.col-md-offset-3
       %p
-        = pluralize(@students.size, 'student')
+        = pluralize(@students_count, 'student')
         and
-        = pluralize(@coaches.size, 'coach')
+        = pluralize(@coaches_count, 'coach')
         in
         = pluralize(@groups.size, 'group')
 

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -22,6 +22,10 @@
       .form-group
         = f.label(:working_on, "What are you working on? (you can use markdown!)")
         = f.text_area :working_on, placeholder: 'tutorials? a cool app?', class: 'form-control', rows: 5, id: 'working-on'
+      .form-group
+        = f.check_box(:non_public)
+        = f.label(:non_public, "Make my account not public")
+        %p.help-block Your account will only be visible to other registered users
 
     .col-md-1
 
@@ -32,21 +36,21 @@
       %ul
         %li You may be contacted by Rails Girls organizers about coaching at various workshops
         %li We will share your email address with trusted organizers
-        %li 
-          Your name will be displayed on our 
-          %a{ href: coaches_path } coaches index page. 
+        %li
+          Your name will be displayed on our
+          %a{ href: coaches_path } coaches index page.
         %li Everyone will think you're really really awesome. And most importantly, you will be.
       %br
       %p Convinced? That's great. We just need a few things from you,
 
       .form-group
         = f.check_box(:workshop_coach)
-        = f.label(:person_workshop_coach, "I am willing to COACH at Rails Girls workshops")
+        = f.label(:workshop_coach, "I am willing to COACH at Rails Girls workshops")
 
       .form-group
         = f.check_box(:willing_to_travel)
         = f.label(:willing_to_travel, "I am willing to TRAVEL to Rails Girls workshops")
-      
+
       .form-group
         = f.label(:city, "City")
         = f.text_field :city, placeholder: 'Rubycity', class: 'form-control'

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -41,6 +41,10 @@
         %p
           %strong Based in:
           #{@person.city} #{@person.country_name}
+      - if logged_in?(@person) && @person.non_public?
+        %p.bg-info
+          Your account is not public <br>
+          %small (only registered users can see your profile)
     .col-md-4
       %h4 Project Groups:
       - if @person.has_group?

--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,3 @@
+browsers:
+  - "last 2 versions"
+  - "IE > 10"

--- a/db/migrate/20170127155731_add_non_public_flag_to_people.rb
+++ b/db/migrate/20170127155731_add_non_public_flag_to_people.rb
@@ -1,0 +1,5 @@
+class AddNonPublicFlagToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :non_public, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621202750) do
+ActiveRecord::Schema.define(version: 20170127155731) do
 
   create_table "comments", force: :cascade do |t|
     t.string   "person_id",  null: false
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 20160621202750) do
     t.string   "city",                   limit: 255
     t.string   "country",                limit: 255
     t.string   "website",                limit: 255
+    t.boolean  "non_public",                         default: false, null: false
   end
 
   add_index "people", ["email"], name: "index_people_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,7 +81,8 @@ user_list = [
     twitter: '@anotherstudenttwitter',
     country: 'CA',
     city: 'Toronto',
-    membership: 'Student'
+    membership: 'Student',
+    non_public: true
   },
   {
     first_name: 'Sara',
@@ -92,7 +93,8 @@ user_list = [
     admin: true,
     country: 'US',
     city: 'New York',
-    membership: 'Coach'
+    membership: 'Coach',
+    workshop_coach: true
   },
   {
     first_name: 'Lisa',
@@ -103,7 +105,9 @@ user_list = [
     admin: false,
     country: 'US',
     city: 'New York',
-    membership: 'Coach'
+    membership: 'Coach',
+    non_public: true,
+    workshop_coach: true
   }
 ]
 user_list.map do |user|

--- a/spec/features/people_non_public_profile_spec.rb
+++ b/spec/features/people_non_public_profile_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+feature 'person profle visibility' do
+
+  let(:person) { create(:person) }
+  let(:person2) { create(:person)}
+
+  scenario 'non public profile setting' do
+    visit new_person_session_path
+    sign_in person
+    visit person_path(person)
+    expect(page).to_not have_content('Your account is not public')
+
+    click_link 'edit'
+    check "Make my account not public"
+    click_button 'Save'
+    expect(page).to have_content('Your account is not public')
+
+    click_link 'All'
+    expect(page).to have_content('Ruby Corn')
+
+    click_link 'logout'
+    click_link 'All'
+    expect(page).to_not have_content('Ruby Corn')
+
+    visit new_person_session_path
+    sign_in person2
+    click_link 'All'
+    expect(page).to have_content('Ruby Corn')
+
+    person2.update_attribute(:admin, true)
+    expect(page).to have_content('Ruby Corn')
+  end
+end
+
+feature 'coaches list visibility' do
+  let(:person) { create(:person) }
+
+  scenario 'workshop coach non public setting' do
+    visit new_person_session_path
+    sign_in person
+    visit edit_person_path(person)
+    check 'I am willing to COACH at Rails Girls workshops'
+    click_button 'Save'
+    click_link 'logout'
+    visit coaches_path
+    expect(page).to have_content('Ruby Corn')
+
+    visit new_person_session_path
+    sign_in person
+    visit edit_person_path(person)
+    check "Make my account not public"
+    click_button 'Save'
+    click_link 'logout'
+    visit coaches_path
+    expect(page).to_not have_content('Ruby Corn')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   config.order = "random"
   config.include FactoryGirl::Syntax::Methods
   config.include Capybara::DSL
+  config.include Devise::TestHelpers, type: :controller
 end


### PR DESCRIPTION
I added a 'private' flag to user profiles.
When your account is private your account is not visible at all for non-registered/ non-signed-in users.
This means that it does not show on the people overview page or the individual group pages.

Todo: add tests