### PR TITLE
allow users to sign up again

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,21 +1,4 @@
-%h2 Sign up
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "off"
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "off"
-  .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+.container
+  %h2 Sign up
+  = render 'form'
+  = render "devise/shared/links"

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Signing up', :type => :feature do
+  before { visit new_person_registration_path }
+
+  context 'with all required info' do
+    before do
+      fill_in 'First name',            with: 'Ruby'
+      fill_in 'Last name',             with: 'Corn'
+      fill_in 'E-mail',                with: 'ruby.corn@example.org'
+      fill_in 'Password',              with: 'supersecret123'
+      fill_in 'Password Confirmation', with: 'supersecret123'
+      click_button 'Save'
+    end
+
+    it 'creates a user' do
+      expect(page).to have_content("Welcome! You have signed up successfully.")
+      expect(current_path).to eql '/welcome'
+      expect(Person.last.first_name).to eql 'Ruby'
+    end
+  end
+end


### PR DESCRIPTION
looks like our current sign up behaviour is broken. A user is required to provide us with a first name when signing up, but our form only asks for an email & password. So try as you might, you can't sign up!
https://rorganize.it/people/sign_up

This fixes it. We also didn't have a spec for signing up, so it's understandable that this slipped through the cracks.
