### PR TITLE
add alphabetical jump links to people/coach index pages

### DIFF
--- a/app/assets/stylesheets/custom/_groups_people.scss
+++ b/app/assets/stylesheets/custom/_groups_people.scss
@@ -71,3 +71,16 @@
   border: solid 1px #B12200;
   border-radius: 5px;
 }
+
+.alphabetical-list {
+  a {
+    font-size: 1.3em;
+    padding: 0.2em;
+  }
+  margin: 1em 0 1em 0;
+}
+
+.letter-header {
+  font-size: 1.3em;
+  padding: 0.2em;
+}

--- a/app/controllers/coaches_controller.rb
+++ b/app/controllers/coaches_controller.rb
@@ -7,5 +7,8 @@ class CoachesController < ApplicationController
     @coaches = @coaches.willing_to_travel if params[:willing_to_travel] == '1'
     @cities  = Person.workshop_coach.cities
     @countries = Person.workshop_coach.countries
+
+    @grouped_coaches = @coaches.group_by{|person| person.first_name.first.capitalize }
+    @alphabetical_list = @grouped_coaches.keys.sort
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,9 +7,11 @@ class PeopleController < ApplicationController
     @people = @people.public_profile unless signed_in?
     @people = @people.by_country(params[:country]) if params[:country].present?
     @people = @people.by_city(params[:city]) if params[:city].present?
-
     @cities = Person.cities
     @countries = Person.countries
+
+    @grouped_people = @people.group_by{|person| person.first_name.first.capitalize }
+    @alphabetical_list = @grouped_people.keys.sort
   end
 
   def show

--- a/app/views/coaches/index.html.haml
+++ b/app/views/coaches/index.html.haml
@@ -20,19 +20,9 @@
           and then fill in the relevant info on your profile page.
 
   %hr
-  .row
-    .col-md-8
-      %ul.list-group
-        - @coaches.each do |coach|
-          %li.list-group-item.clearfix
-            .row
-              .col-md-2
-                = person_avatar(coach)
-              .col-md-8
-                %h3
-                  = profile_link(coach)
-                - if logged_in? && location_for?(coach)
-                  %p #{coach.city} #{coach.country_name}
+  = render partial: 'shared/alphabetical_list', locals: { alphabetical_list: @alphabetical_list}
 
+  .row
+    = render partial: 'shared/grouped_people', locals: { grouped_people: @grouped_coaches, coach_page: true }
     %aside.sidebar.col-md-4
       = render partial: 'shared/filter', locals: { path: coaches_path }

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -1,17 +1,8 @@
 .container.student-list
   %h1.page-header People overview
-  .row
-    .col-md-8
-      %ul.list-group
-        - @people.each do |person|
-          %li{class: "list-group-item clearfix #{'list-group-item-warning' if logged_in?(person)}"}
-            .row
-              .col-md-2
-                = person_avatar(person)
-              .col-md-8
-                %h3
-                  = profile_link(person)
-                = render partial: "shared/groups", locals: { object: person }
+  = render partial: 'shared/alphabetical_list', locals: { alphabetical_list: @alphabetical_list}
 
+  .row
+    = render partial: 'shared/grouped_people', locals: { grouped_people: @grouped_people, coach_page: false }
     %aside.sidebar.col-md-4
       = render partial: 'shared/filter', locals: { path: people_path }

--- a/app/views/shared/_alphabetical_list.haml
+++ b/app/views/shared/_alphabetical_list.haml
@@ -1,0 +1,4 @@
+.alphabetical-list
+  - alphabetical_list.map do |letter|
+    %a{href: "##{letter}"}
+      = letter

--- a/app/views/shared/_grouped_people.haml
+++ b/app/views/shared/_grouped_people.haml
@@ -1,0 +1,17 @@
+.col-md-8
+  %ul.list-group
+    - grouped_people.sort.each do |letter, people|
+      .letter-header{id: "#{letter}"}
+        = letter
+      - people.each do |person|
+        %li{class: "list-group-item clearfix #{'list-group-item-warning' if logged_in?(person)}"}
+          .row
+            .col-md-2
+              = person_avatar(person)
+            .col-md-8
+              %h3
+                = profile_link(person)
+              - if !coach_page
+                = render partial: "shared/groups", locals: { object: person }
+              - elsif logged_in? && location_for?(person)
+                %p #{person.city} #{person.country_name}


### PR DESCRIPTION
This is semi-resolving issue #370 
I added alphabetical jump links for the people and coaches index pages, exciting stuff! I also refactored a bit as there was a lot of repetition between the people#index and the coach#index. I pulled a bunch of it out into partials. 
I'm only working in the non-redesign area thou, as I don't want to touch the redesign stuff until it's up and running & for realz. But since this is mostly in partials, switching it over to the redesign when ready shouldn't be much of a problem. 

I have no specs, as it's mostly display stuff & I don't really want to write a feature spec for this. But maybe a little bit of a controller spec? Thoughts?

Anyway, here's a screenshot:
![screenshot from 2017-02-07 16-35-29](https://cloud.githubusercontent.com/assets/4237285/22698366/a2504390-ed54-11e6-8adb-d364c891620e.png)

As always, review & comments always welcome!