### PR TITLE
paginate person & coach index pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    will_paginate (3.0.5)
+    will_paginate (3.1.5)
     win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -404,4 +404,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  require 'will_paginate/array'
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/coaches_controller.rb
+++ b/app/controllers/coaches_controller.rb
@@ -1,16 +1,20 @@
 class CoachesController < ApplicationController
   def index
-    ordered_coaches = Person.workshop_coach.order_by_name
-    coaches_by_region = ordered_coaches
-                          .filtered_by_region(params)
-                          .filtered_by_visibility(signed_in?)
+    coaches = Person.workshop_coach.order_by_name
+                .filtered_by_region(params)
+                .filtered_by_visibility(signed_in?)
 
     @willing_to_travel = params[:willing_to_travel] == '1'
-    @coaches = @willing_to_travel ? coaches_by_region.willing_to_travel : coaches_by_region
+    @coaches = @willing_to_travel ? coaches.willing_to_travel : coaches
     @cities  = Person.workshop_coach.visible_locations_for(:cities, signed_in?)
     @countries = Person.workshop_coach.visible_locations_for(:countries, signed_in?)
 
-    @grouped_coaches = @coaches.group_by{|person| person.first_name.first.capitalize }
-    @alphabetical_list = @grouped_coaches.keys.sort
+    page = (params[:page] || 1).to_i
+
+    @paginated_coaches = @coaches.paginate(page: page, per_page: 30)
+    @alphabetically_grouped_coaches = @paginated_coaches.grouped_alphabetically
+
+    @paginated_alphabetical_list = @alphabetically_grouped_coaches.keys
+    @total_alphabetical_list = coaches.grouped_alphabetically.keys
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,16 +3,19 @@ class PeopleController < ApplicationController
   before_action :set_person, only: [:show, :edit, :update, :destroy]
 
   def index
-    ordered_people = Person.order(:first_name).order(:last_name)
-    @people = ordered_people
-                .filtered_by_region(params)
-                .filtered_by_visibility(signed_in?)
+    filtered_people = Person.order_by_name.filtered_by_region(params)
+                        .filtered_by_visibility(signed_in?)
 
     @cities = Person.visible_locations_for(:cities, signed_in?)
     @countries = Person.visible_locations_for(:countries, signed_in?)
 
-    @grouped_people = @people.group_by{|person| person.first_name.first.capitalize }
-    @alphabetical_list = @grouped_people.keys.sort
+    page = (params[:page] || 1).to_i
+
+    @paginated_people = filtered_people.paginate(page: page, per_page: 30)
+    @alphabetically_grouped_people = @paginated_people.grouped_alphabetically
+
+    @paginated_alphabetical_list = @alphabetically_grouped_people.keys
+    @total_alphabetical_list = filtered_people.grouped_alphabetically.keys
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,8 +4,6 @@ class PostsController < ApplicationController
   before_action :authenticate_person!, except: [:index, :show]
   before_action :check_role, except: [:index, :show]
 
-  require 'will_paginate/array'
-
   def index
     @published_posts = Post.published_descending_order
     page = (params[:page] || 1).to_i

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -121,6 +121,10 @@ class Person < ActiveRecord::Base
     true
   end
 
+  def self.grouped_alphabetically
+    all.order_by_name.group_by{|person| person.first_name.first.capitalize }
+  end
+
   private
     def prepend_http
       if website.present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -122,7 +122,9 @@ class Person < ActiveRecord::Base
   end
 
   def self.grouped_alphabetically
-    all.order_by_name.group_by{|person| person.first_name.first.capitalize }
+    all.order_by_name.group_by do |person|
+      person.first_name ? person.first_name.first.capitalize : '*'
+    end
   end
 
   private

--- a/app/views/coaches/index.html.haml
+++ b/app/views/coaches/index.html.haml
@@ -20,9 +20,12 @@
           and then fill in the relevant info on your profile page.
 
   %hr
-  = render partial: 'shared/alphabetical_list', locals: { alphabetical_list: @alphabetical_list}
+  = render partial: 'shared/alphabetical_list', locals: { paginated_alphabetical_list: @paginated_alphabetical_list, total_alphabetical_list: @total_alphabetical_list }
 
+  = will_paginate @paginated_coaches
   .row
-    = render partial: 'shared/grouped_people', locals: { grouped_people: @grouped_coaches, coach_page: true }
+    = render partial: 'shared/grouped_people', locals: { grouped_people: @alphabetically_grouped_coaches, coach_page: true }
     %aside.sidebar.col-md-4
       = render partial: 'shared/filter', locals: { path: coaches_path }
+
+  = will_paginate @paginated_coaches

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -1,8 +1,11 @@
 .container.student-list
   %h1.page-header People overview
-  = render partial: 'shared/alphabetical_list', locals: { alphabetical_list: @alphabetical_list}
+  = render partial: 'shared/alphabetical_list', locals: { paginated_alphabetical_list: @paginated_alphabetical_list, total_alphabetical_list: @total_alphabetical_list }
 
+  = will_paginate @paginated_people
   .row
-    = render partial: 'shared/grouped_people', locals: { grouped_people: @grouped_people, coach_page: false }
+    = render partial: 'shared/grouped_people', locals: { grouped_people: @alphabetically_grouped_people, coach_page: false }
     %aside.sidebar.col-md-4
       = render partial: 'shared/filter', locals: { path: people_path }
+
+  = will_paginate @paginated_people

--- a/app/views/shared/_alphabetical_list.haml
+++ b/app/views/shared/_alphabetical_list.haml
@@ -1,4 +1,6 @@
 .alphabetical-list
-  - alphabetical_list.map do |letter|
+  = '...' unless total_alphabetical_list[0] == paginated_alphabetical_list.first
+  - paginated_alphabetical_list.map do |letter|
     %a{href: "##{letter}"}
       = letter
+  = '...' unless total_alphabetical_list[-1] == paginated_alphabetical_list.last

--- a/spec/controllers/coaches_controller_spec.rb
+++ b/spec/controllers/coaches_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe CoachesController do
+
+  describe 'index' do
+    let!(:coach) { create :person, first_name: 'Corn', workshop_coach: true }
+
+    before :each do
+      get :index
+    end
+
+    it 'is successful' do
+      expect(response).to be_success
+    end
+
+    it 'has a list of people' do
+      expect(assigns(:paginated_coaches)).to include coach
+    end
+
+    it 'has a list of people grouped alphabetically' do
+      expect(assigns(:alphabetically_grouped_coaches)).to eql({'C' => [coach] })
+    end
+
+    it 'has a paginated list of alphabet keys' do
+      expect(assigns(:paginated_alphabetical_list)).to eql ['C']
+    end
+
+    it 'has a list of all alphabet keys for all people' do
+      expect(assigns(:total_alphabetical_list)).to eql ['C']
+    end
+  end
+end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PeopleController do
 
   describe 'index' do
-    let!(:person) { create(:person) }
+    let!(:person) { create :person, first_name: 'Ruby' }
 
     before :each do
       get :index
@@ -14,7 +14,19 @@ describe PeopleController do
     end
 
     it 'has a list of people' do
-      expect(assigns(:people)).to include person
+      expect(assigns(:paginated_people)).to include person
+    end
+
+    it 'has a list of people grouped alphabetically' do
+      expect(assigns(:alphabetically_grouped_people)).to eql({'R' => [person] })
+    end
+
+    it 'has a paginated list of alphabet keys' do
+      expect(assigns(:paginated_alphabetical_list)).to eql ['R']
+    end
+
+    it 'has a list of all alphabet keys for all people' do
+      expect(assigns(:total_alphabetical_list)).to eql ['R']
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -267,11 +267,13 @@ describe Person, vcr: {cassette_name: 'create_group'} do
   describe '.grouped_alphabetically' do
     let!(:person)  { create :person, first_name: 'Zed' }
     let!(:person2) { create :person, first_name: 'Betty'}
-    let!(:person3) { create :person, first_name: 'Mary'}
+    let!(:person3) { create :person, first_name: 'Mary' }
+    let!(:person4) { create :person, first_name: '123'}
+
+    before { person3.update_attribute(:first_name, nil) } # in the unlikely case that a user doesn't have a first name
 
     it 'returns people grouped by the first letter of their name' do
-      expect(Person.grouped_alphabetically.keys).to eql ['B', 'M', 'Z']
-      expect(Person.grouped_alphabetically.values.flatten).to match_array [person2, person3, person]
+      expect(Person.grouped_alphabetically).to eql({'*'=>[person3], '1'=>[person4], 'B'=>[person2], 'Z'=>[person]})
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -263,4 +263,15 @@ describe Person, vcr: {cassette_name: 'create_group'} do
       end
     end
   end
+
+  describe '.grouped_alphabetically' do
+    let!(:person)  { create :person, first_name: 'Zed' }
+    let!(:person2) { create :person, first_name: 'Betty'}
+    let!(:person3) { create :person, first_name: 'Mary'}
+
+    it 'returns people grouped by the first letter of their name' do
+      expect(Person.grouped_alphabetically.keys).to eql ['B', 'M', 'Z']
+      expect(Person.grouped_alphabetically.values.flatten).to match_array [person2, person3, person]
+    end
+  end
 end


### PR DESCRIPTION
Final step in https://github.com/rubycorns/rorganize.it/issues/370

I added pagination to the people#index & coaches#index, which is also represented in the alphabetical jump links & also works based on the filtering selected. See screenshots for examples. 

One could argue that there's some repetition in the controllers... any suggestions for how to improve this (or anything else of course) is very welcome. I also tried to be super explicit about naming my instance variables in the controllers, so I hope they're not confusing. If they are, please let me know. 

I also thought that maybe my code to add `'...'` to the beginning and end of the alphabetical list [here](https://github.com/rubycorns/rorganize.it/blob/paginate-user-page/app/views/shared/_alphabetical_list.haml#L2) could be moved elsewhere... but I'm not sure where. In other projects I've worked on we've used decorators, and I think that would be a good place for this but we don't use decorators. So... hmmmmmm.....

#### page 1
![screenshot from 2017-02-21 14-17-29](https://cloud.githubusercontent.com/assets/4237285/23166451/f595c3a8-f840-11e6-8c08-b4aac25caa72.png)

#### page 2
![screenshot from 2017-02-21 14-17-55](https://cloud.githubusercontent.com/assets/4237285/23166453/f78f31bc-f840-11e6-8960-b0db41388721.png)

#### using filter (Berlin selected)
![screenshot from 2017-02-21 14-18-13](https://cloud.githubusercontent.com/assets/4237285/23166457/f9eb059e-f840-11e6-8f6b-06d6620e6a66.png)
