### PR TITLE
update some of the group show page layout

### DIFF
--- a/app/assets/stylesheets/custom/_buttons.scss
+++ b/app/assets/stylesheets/custom/_buttons.scss
@@ -1,6 +1,7 @@
 // DIV for action buttons
 .action-buttons {
   margin: 1rem 0;
+  text-align: right;
   & > * {
     margin-right: 0.5rem;
   }

--- a/app/assets/stylesheets/custom/_profiles.scss
+++ b/app/assets/stylesheets/custom/_profiles.scss
@@ -3,6 +3,7 @@
 .flex-profile {
   display: flex;
   justify-content: space-between;
+  flex-direction: column;
   .profile-contact {
     flex-basis: 20%;
     display: flex;
@@ -11,11 +12,21 @@
   .profile-main {
     flex-basis: 75%;
   }
+
+  @media (min-width: $mq-med) {
+    flex-direction: row;
+  }
+
 }
 
 .profile-contact img {
-  width: 90%;
+  width: 50%;
   height: auto;
+  margin: 0 auto;
+
+  @media (min-width: $mq-med) {
+    width: 90%;
+  }
 }
 
 #map {
@@ -23,6 +34,13 @@
   width: 200px;
   overflow: hidden;
   margin-top: 1rem;
+}
+
+#group-map {
+  margin: 0 auto;
+  @media (min-width: $mq-med) {
+    margin: 0;
+  }
 }
 
 .group-leave {

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,6 +1,18 @@
 %ul.sub-nav{role: "navigation"}
   %li= link_to "← All groups", groups_path
 
+- if show_member_buttons?(current_person, @group) || current_person.admin?
+  .action-buttons
+    - if show_member_buttons?(current_person, @group)
+      %span
+        = link_to edit_group_path(@group), class: 'btn btn-teal' do
+          Edit group
+      = render 'leave'
+    - if current_person.admin?
+      %span
+        = link_to edit_group_path(@group), class: 'btn btn-pink' do
+          Edit as admin &#9873;
+
 %h1.page-header= @group.name
 .flex-profile
   %aside.profile-contact
@@ -46,18 +58,6 @@
         = image_tag('follow_your_dreams.gif')
 
   .profile-main
-    - if show_member_buttons?(current_person, @group) || current_person.admin?
-      .action-buttons
-        - if show_member_buttons?(current_person, @group)
-          %span
-            = link_to edit_group_path(@group), class: 'btn btn-teal' do
-              Edit group
-          = render 'leave'
-        - if current_person.admin?
-          %span
-            = link_to edit_group_path(@group), class: 'btn btn-pink' do
-              Edit as admin &#9873;
-
     %p.tags
       - if @group.full?
         %span.tag.tag-full


### PR DESCRIPTION
Just updating some of the layouts to help spread out the infos.

In this pull request I am going to update the group show page. Below are some screenshots to demonstrate what it looks like now and what the updates will do.

Current:
<img width="515" alt="screen shot 2017-04-11 at 21 23 05" src="https://cloud.githubusercontent.com/assets/1307818/24926888/65cd6346-1efd-11e7-8d1d-ec5864af30d8.png">

What this PR changes it to:
<img width="517" alt="screen shot 2017-04-11 at 21 23 14" src="https://cloud.githubusercontent.com/assets/1307818/24926907/74160980-1efd-11e7-9a6a-543c0f7752d7.png">

Note that these pictures look a bit big, but they are on a 500px screen, so imagine mobile. Feel free to pull the branch in and try it out yourself 

Many thanks in advance for the review liebe Rubycorns!!
