### PR TITLE
Capitalizing City Name Before Save - in progress

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -72,6 +72,5 @@ class GroupsController < ApplicationController
     :picture, :twitter, :contact, :activities, :email, :level,
     :founded_on, :join_as_coach, :full, :city, :country, :street, :zip,
     :learning_resources, :inactive, :allow_male_students)
-  end
-
+  end 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -49,6 +49,8 @@ class Group < ActiveRecord::Base
   geocoded_by :location
   after_validation :geocode
 
+  before_save :capitalize_fields
+
   extend FriendlyId
   friendly_id :name, use: :slugged
 
@@ -72,5 +74,9 @@ class Group < ActiveRecord::Base
 
   def location
     [address, street, zip, city, country].join(' ')
+  end
+
+  def capitalize_fields
+    self.city = city.titleize
   end
 end


### PR DESCRIPTION
This Addresses Issue #535.

In The Group Model, I've Added A `before_save` Method To Capitalize A City's Name Before Saving To The Database.