### PR TITLE
fixes 557 with px units

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,11 +208,6 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    pry (0.9.12.6-i386-mingw32)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-      win32console (~> 1.3)
     pry (0.9.12.6-x86-mingw32)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -396,4 +391,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/app/assets/stylesheets/custom/_layout.scss
+++ b/app/assets/stylesheets/custom/_layout.scss
@@ -91,8 +91,8 @@ nav.navbar {
     display: block;
   }
   img {
-    height: 62%;
-    width: auto;
+    height: auto;
+    width: 175px;
   }
 }
 


### PR DESCRIPTION
fixes #557 
Short and sweet addition, as the logo was jumping up to take 60% of the page, and not its container. 

Probably good to have a set height on the logo, so thought this was a good solution

