### PR TITLE
display alphabetical group when clicked (pagination)

### DIFF
--- a/app/assets/stylesheets/custom/_lists.scss
+++ b/app/assets/stylesheets/custom/_lists.scss
@@ -77,6 +77,10 @@
   padding: 0.2em;
 }
 
+.letter-header {
+  display: block;
+}
+
 .alphabetical-list {
   a {
     font-size: 1.3em;
@@ -94,4 +98,16 @@
   font-size: 0.8em;
   text-transform: uppercase;
   color: $salmon-pink;
+}
+
+.person-group {
+  display: none;
+}
+
+.person-group:target ~ .person-group:last-of-type {
+  display: none;
+}
+
+.person-group:last-of-type, .person-group:target {
+  display: block;
 }

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -11,3 +11,10 @@
 
   %aside.flex-index-sidebar
     = render partial: 'shared/filter', locals: { path: people_path }
+
+
+%script
+  :plain
+  if (window.location.hash === '') {
+    window.location.hash = "#{@alphabetical_list.first}";
+  }

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -13,8 +13,8 @@
     = render partial: 'shared/filter', locals: { path: people_path }
 
 
-%script
-  :plain
+:javascript
   if (window.location.hash === '') {
     window.location.hash = "#{@alphabetical_list.first}";
   }
+  

--- a/app/views/shared/_grouped_people.haml
+++ b/app/views/shared/_grouped_people.haml
@@ -1,19 +1,20 @@
 %ul.list-group
   - grouped_people.sort.each do |letter, people|
-    .letter-header{id: "#{letter}"}
-      = letter
-    - people.each do |person|
-      %li{class: "list-group-item clearfix #{'list-group-item-warning' if logged_in?(person)}"}
-        .list-group-item-pic
-          = person_avatar(person)
-        .list-group-item-info
-          %h3
-            = profile_link(person)
-          - if person.searching_group?
-            %span.tag Searching for a group
-          = render partial: "shared/groups", locals: { object: person }
-          - if logged_in?(person)
-            .list-group-item-person
-              It's you
-            - if location_for?(person)
-              %p #{person.city} #{person.country_name}
+    .person-group{id: "#{letter}"}
+      .letter-header
+        = letter
+      - people.each do |person|
+        %li{class: "list-group-item clearfix #{'list-group-item-warning' if logged_in?(person)}"}
+          .list-group-item-pic
+            = person_avatar(person)
+          .list-group-item-info
+            %h3
+              = profile_link(person)
+            - if person.searching_group?
+              %span.tag Searching for a group
+            = render partial: "shared/groups", locals: { object: person }
+            - if logged_in?(person)
+              .list-group-item-person
+                It's you
+              - if location_for?(person)
+                %p #{person.city} #{person.country_name}


### PR DESCRIPTION
retry for https://github.com/rubycorns/rorganize.it/pull/512

slight problem is, if we have an alphabetical list (from A-Z) and go to /people, we display the people whose names start with Z first, not the ppl whose names start with A. 

@sareg0 is gonna take another look at this! suggestions welcome on how to get the page to display at A group first :)

(ex: in the screenshot you can see that if you go to /people the last alphabetical group of people is shown first)

![screenshot from 2017-09-26 21-57-23](https://user-images.githubusercontent.com/4237285/30881325-b70410de-a305-11e7-852a-786a0b0df0b7.png)
