### PR TITLE
Fix signup form to autofocus first input field

### DIFF
--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -2,13 +2,13 @@
   = devise_error_messages!
   .form-group
     = label_tag(:first_name, "Your first name *")
-    = f.text_field :first_name, placeholder: 'First name'
+    = f.text_field :first_name, placeholder: 'First name', autofocus: true
   .form-group
     = label_tag(:last_name, "Your last name")
     = f.text_field :last_name, placeholder: 'Last name'
   .form-group
     = label_tag(:email, "Your email address *")
-    = f.email_field :email, autofocus: true, placeholder: 'email@email.com'
+    = f.email_field :email, placeholder: 'email@email.com'
     %p.help-block (don't worry, your email won't be displayed publicly)
   .form-group
     = label_tag(:password, "Enter your password *")

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'Signing up', :type => :feature do
   before { visit new_person_registration_path }
 
+  it 'initially focuses first form input field' do
+    expect(first('input[type="text"]')['autofocus']).to eql 'autofocus'
+  end
+
   context 'with all required info' do
     before do
       fill_in 'First name',       with: 'Ruby'


### PR DESCRIPTION
### Small usability fix:
Signup form in `registrations#new` view should initially focus the first input field, not the third one

#### Before

![bildschirmfoto 2017-10-29 um 14 41 17](https://user-images.githubusercontent.com/34942/32144930-e1b5f1d8-bcc0-11e7-8717-cd9a2ac9a1ab.png)

#### After

![bildschirmfoto 2017-10-29 um 15 49 20](https://user-images.githubusercontent.com/34942/32144928-dc754ba6-bcc0-11e7-8752-46f481f165b4.png)
