### PR TITLE
Don't allow http connections during specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require 'database_cleaner'
 require 'shoulda-matchers'
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -16,6 +19,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
+
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,5 +4,6 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   c.hook_into :webmock
   c.default_cassette_options = { :record => :new_episodes}
+  c.allow_http_connections_when_no_cassette = false
   c.configure_rspec_metadata!
 end


### PR DESCRIPTION
This disables http connections when running specs to ensure tests are run against the fixtures, not the live apis. Our tests shouldn't depend on the reachability of the apis to work. 

Verified that it works by disabling wifi. Tests in master fail with 'could not connect to geocoding api', tests in this branch work. 