### PR TITLE
fix main nav item too close bug

### DIFF
--- a/app/assets/stylesheets/custom/_nav.scss
+++ b/app/assets/stylesheets/custom/_nav.scss
@@ -56,7 +56,7 @@ nav.navbar {
         border-color: $salmon-pink;
       }
       &:first-of-type {
-        padding-left: 0;
+        margin-left: 20px;
       }
     }
     &.active a {


### PR DESCRIPTION
This PR fixes the navigation item been too close. A design bug 
#### Is this solving an issue already in our backlog? If so, please mention which one
#593 
#### Special things about this PR to be considered
The PR fixes the design issue in the navigation item been too close by tweaking the css responsible
#### Do you have any open Questions you need to get answered?
None
#### Please outline the areas that should be tested, if there are any:
- Visit the website and check out the main navigation. You will notice more spaces between the main navigation item.
#### A snapshot is seen below
**The current state**

<img width="1280" alt="screen shot 2018-02-01 at 3 57 36 pm" src="https://user-images.githubusercontent.com/28534124/35684976-b3304370-0768-11e8-983d-be905797573b.png">

**The desired state based on my implementation**

<img width="1277" alt="screen shot 2018-02-01 at 3 56 51 pm" src="https://user-images.githubusercontent.com/28534124/35685018-c9c8337c-0768-11e8-870f-5dd9afec1107.png">

