### PR TITLE
Remove devise deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/**/*"
+    - "bin/**/*"
+    - "config/**/*"
+    - "app/assets/**/*"
+    - "Rakefile"
+    - "micro-shared/**/*"
+    - "Gemfile"
+    - "Gemfile.lock"
+  UseCache: false
+  TargetRubyVersion: 2.4
+  TargetRailsVersion: 5.0.7
+Rails/HttpPositionalArguments:
+  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
+  Enabled: true
+  Include:
+    - 'spec/**/*'
+    - 'test/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'friendly_id'
 
 gem "pry"
 
+gem "rubocop"
+
 group :development do
   gem 'sqlite3'
   gem 'guard-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     arel (7.1.4)
+    ast (2.4.0)
     bcrypt (3.1.11)
     better_errors (2.4.0)
       coderay (>= 1.0.0)
@@ -215,7 +216,11 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
+    parallel (1.12.1)
+    parser (2.5.0.5)
+      ast (~> 2.4.0)
     pg (0.21.0)
+    powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -254,6 +259,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -287,6 +293,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    rubocop (0.54.0)
+      parallel (~> 1.10)
+      parser (>= 2.5)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
@@ -333,6 +347,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.6)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.3.0)
     unicode_utils (1.4.0)
     vcr (4.0.0)
     warden (1.2.7)
@@ -389,6 +404,7 @@ DEPENDENCIES
   redcarpet
   rspec-its (~> 1.0.1)
   rspec-rails (>= 3.5)
+  rubocop
   sass-rails
   sdoc
   shoulda-matchers

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -13,12 +13,12 @@ describe AdminsController do
   describe 'create' do
 
     it 'is not allowed for normal users' do
-      post :create, id: person.id
+      post :create, params: { id: person.id }
       expect(person.admin?).to be false
     end
 
     it 'gives admin powers to an admin user' do
-      post :create, id: admin.id
+      post :create, params: { id: admin.id }
       expect(admin.admin?).to be true
     end
   end
@@ -26,7 +26,7 @@ describe AdminsController do
   describe 'destroy' do
 
     it 'removes admin power from a user' do
-      delete :destroy, id: admin.id
+      delete :destroy, params: { id: admin.id }
       expect(admin.reload.admin?).to be false
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -15,12 +15,12 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
 
       it 'creates a new group' do
         expect do
-          post :create, params
+          post :create, params: params
         end.to change{ Group.count }.by(1)
       end
 
       it 'redirects to the group show page' do
-        post :create, params
+        post :create, params: params
         expect(response).to redirect_to group_path(Group.first)
       end
     end
@@ -34,7 +34,7 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
       end
 
       it 'redirects to the sign in path' do
-        post :create, params
+        post :create, params: params
         expect(response).to render_template(:new)
       end
     end
@@ -59,22 +59,22 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
 
       it 'updates the group' do
         expect do
-          put :update, params
+          put :update, params: params
         end.not_to change{ Group.count }
       end
 
       it 'updates the name of the group' do
-        put :update, params
+        put :update, params: params
         expect(Group.find_by(name: 'Changed group name')).to_not be nil
       end
 
       it 'redirects to the groups overview' do
-        put :update, params
+        put :update, params: params
         expect(response).to redirect_to group_path(group)
       end
 
       it 'displays the correct notice' do
-        put :update, params
+        put :update, params: params
         expect(flash[:notice]).to match /updated/
       end
     end
@@ -82,12 +82,12 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
     context 'as a non-member of the group' do
 
       it 'does not update the name of the group' do
-        put :update, params
+        put :update, params: params
         expect(group.name).to eq 'Awesome Group'
       end
 
       it 'redirects to the groups overview' do
-        put :update, params
+        put :update, params: params
         expect(response.status).to eq 403
       end
     end
@@ -107,13 +107,13 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
     context 'as a non-admin' do
 
       it 'does not allow a non-admin to delete a group' do
-        delete :destroy, id: group.id
+        delete :destroy, params: { id: group.id }
         expect(response.status).to eq 403
       end
 
       it 'does not delete the group' do
         expect do
-          delete :destroy, id: group.id
+          delete :destroy, params: { id: group.id }
         end.not_to change { Group.count }
       end
     end
@@ -125,18 +125,18 @@ describe GroupsController, vcr: {cassette_name: 'create_group'} do
       end
 
       it 'redirects to the groups path after successful deletion' do
-        delete :destroy, id: group.id
+        delete :destroy, params: { id: group.id }
         expect(response).to redirect_to groups_path
       end
 
       it 'displays the correct notice' do
-        delete :destroy, id: group.id
+        delete :destroy, params: { id: group.id }
         expect(flash[:notice]).to match /success/
       end
 
       it 'deletes the group' do
         expect do
-          delete :destroy, id: group.id
+          delete :destroy, params: { id: group.id }
         end.to change{ Group.count }.by(-1)
       end
     end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -14,23 +14,23 @@ describe MembershipsController, vcr: {cassette_name: 'create_group'} do
 
     it 'creates a membership' do
       expect do
-        post :create, params
+        post :create, params: params
       end.to change{ Membership.count}.by(1)
     end
 
     it 'sends an email to the group' do
       expect do
-        post :create, params
+        post :create, params: params
       end.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
 
     it 'renders the correct message' do
-      post :create, params
+      post :create, params: params
       expect(flash[:success]).not_to be_blank
     end
 
     it 'redirects to the group path' do
-      post :create, params
+      post :create, params: params
       expect(response).to redirect_to group_path(group)
     end
   end
@@ -45,18 +45,18 @@ describe MembershipsController, vcr: {cassette_name: 'create_group'} do
       end
 
       it 'redirects to the groups path after leaving a group' do
-        delete :destroy, id: membership.id
+        delete :destroy, params: { id: membership.id }
         expect(response).to redirect_to groups_path
       end
 
       it 'deletes the membership' do
         expect do
-          delete :destroy, id: membership.id
+          delete :destroy, params: { id: membership.id }
         end.to change{ Membership.count }.by(-1)
       end
 
       it 'displays the correct notice' do
-        delete :destroy, id: membership.id
+        delete :destroy, params: { id: membership.id }
         expect(flash[:success]).to have_content  "You have left your group. No doubt they will miss you. Please consider buying everyone cake on your last day."
       end
     end
@@ -71,12 +71,12 @@ describe MembershipsController, vcr: {cassette_name: 'create_group'} do
 
       it 'deletes the membership' do
         expect do
-          delete :destroy, id: membership.id
+          delete :destroy, params: { id: membership.id }
         end.to change{ Membership.count }.by(-1)
       end
 
       it 'displays the correct notice' do
-        delete :destroy, id: membership.id
+        delete :destroy, params: { id: membership.id }
         expect(flash[:success]).to have_content "You have successfully deleted a person from the group. That was a very tough decision. Cake will make it all better."
       end
     end
@@ -87,7 +87,7 @@ describe MembershipsController, vcr: {cassette_name: 'create_group'} do
 
     it 'does allow a membership to be created' do
       expect do
-        post :create, params
+        post :create, params: params
       end.not_to change{ Membership.count}
     end
   end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -31,12 +31,12 @@ describe PeopleController do
       end
 
       it 'updates the group' do
-        put :update, params
+        put :update, params: params
         expect(person.reload.first_name).to eq 'Buffy'
       end
 
       it 'displays the correct notice' do
-        put :update, params
+        put :update, params: params
         expect(flash[:notice]).to match /updated/
       end
     end
@@ -52,7 +52,7 @@ describe PeopleController do
       end
 
       it 'redirects to the new path' do
-        put :update, params
+        put :update, params: params
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -62,7 +62,7 @@ describe PostsController do
 
         it 'does not create a post' do
           expect do
-            post :create, params
+            post :create, params: params
           end.to_not change{ Post.count}
         end
       end
@@ -76,22 +76,22 @@ describe PostsController do
         context 'publishing the post' do
           it 'is successful' do
             expect do
-              post :create, params
+              post :create, params: params
             end.to change{ Post.count}.by(1)
           end
 
           it 'does not mark the post as a draft' do
-            post :create, params
+            post :create, params: params
             expect(Post.last.draft).to be false
           end
 
           it 'sets the correct published_at date' do
-            post :create, params
+            post :create, params: params
             expect(Post.last.published_at).to eq test_date
           end
 
           it 'redirects to the post' do
-            post :create, params
+            post :create, params: params
             expect(response).to redirect_to post_path(Post.last)
           end
         end
@@ -108,22 +108,22 @@ describe PostsController do
 
           it 'is successful' do
             expect do
-              post :create, params
+              post :create, params: params
             end.to change{ Post.count}.by(1)
           end
 
           it 'marks the post as a draft' do
-            post :create, params
+            post :create, params: params
             expect(Post.last.draft).to be true
           end
 
           it 'sets the correct published_at date' do
-            post :create, params
+            post :create, params: params
             expect(Post.last.published_at).to be_nil
           end
 
           it 'redirects to the post' do
-            post :create, params
+            post :create, params: params
             expect(response).to redirect_to post_path(Post.last)
           end
         end
@@ -158,22 +158,22 @@ describe PostsController do
       context 'updating the post' do
         it 'is successful' do
           expect do
-            put :update, params
+            put :update, params: params
           end.to_not change{ Post.count }
         end
 
         it 'does not mark the post as a draft' do
-          put :update, params
+          put :update, params: params
           expect(post.draft).to be false
         end
 
         it 'keeps the old published_at date' do
-          put :update, params
+          put :update, params: params
           expect(post.published_at).to eq Date.new(2015, 01, 01)
         end
 
         it 'redirects to the post' do
-          put :update, params
+          put :update, params: params
           expect(response).to redirect_to post_path(post)
         end
       end
@@ -186,18 +186,18 @@ describe PostsController do
         let(:post) { create :post, draft: true, published_at: nil }
 
         it 'sets draft to false, b/c it is published' do
-          put :update, params
+          put :update, params: params
           expect(Post.find_by(slug: post.slug).draft).to be false
         end
 
         it 'sets the correct published_at
          date' do
-          put :update, params
+          put :update, params: params
           expect(Post.find_by(slug: post.slug).published_at).to eq test_date
         end
 
         it 'redirects to the post' do
-          put :update, params
+          put :update, params: params
           expect(response).to redirect_to post_path(post)
         end
       end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -18,17 +18,17 @@ describe RegistrationsController do
 
     it "deletes the user's account" do
       expect do
-        delete :destroy, id: person.id
+        delete :destroy, params: { id: person.id }
       end.to change{ Person.count }.by(-1)
     end
 
     it 'redirects to the root page' do
-      delete :destroy, id: person.id
+      delete :destroy, params: { id: person.id }
       expect(response).to redirect_to root_path
     end
 
     it 'displays the correct notice' do
-      delete :destroy, id: person.id
+      delete :destroy, params: { id: person.id }
       expect(flash[:notice]).to match /success/
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,6 @@ RSpec.configure do |config|
   config.order = "random"
   config.include FactoryBot::Syntax::Methods
   config.include Capybara::DSL
-  config.include Devise::TestHelpers, type: :controller
-  # config.include Devise::Test::ControllerHelpers
+  # config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
#### Is this solving an issue already in our backlog? If so, please mention which one
It removes all devise deprecation warnings as specified [here](https://github.com/rubycorns/rorganize.it/issues/621)


#### Special things about this PR to be considered
Rubocop was added as a form of linter, more rules can be added later.


#### Do you have any open Questions you need to get answered?
none


#### Please outline the areas that should be tested, if there are any:
The tests by running `rspec`

